### PR TITLE
Only pass good data to API layer

### DIFF
--- a/lib/api/category.js
+++ b/lib/api/category.js
@@ -3,7 +3,7 @@ const {knex} = require('../database');
 const errors = require('../errors');
 const events = require('../events');
 const analytics = require('../services/analytics');
-const {grade: {create: Grade}, category: {create: NewCategory}} = require('../models');
+const {grade: {create: Grade}, category: {create: Category}} = require('../models');
 const base = require('./base');
 
 const MODEL_NAME = 'category';
@@ -65,37 +65,39 @@ module.exports = {
 
 		return response;
 	},
-	async create(body) {
-		const txn = await knex.transaction();
+	async create(data, transaction = false) {
+		const CATEGORY_PROPERTIES = ['name', 'weight', 'position', 'course_id'];
+		// @note: a non-expanded category has a grade without a name
+		const GRADE_PROPERTIES = ['course_id', 'user_id', 'grade'];
+		const txn = transaction || await knex.transaction();
 
-		const CATEGORY_PROPERTIES = ['id', 'course_id', 'name', 'weight', 'position'];
-		const GRADE_PROPERTIES = ['user_id', 'course_id', 'grade'];
-
-		const categoryModel = new NewCategory();
-		const gradeModel = new Grade();
-
-		for (const property of CATEGORY_PROPERTIES) {
-			if (property in body) {
-				categoryModel.set(property, body[property]);
-			}
-		}
-
-		for (const property of GRADE_PROPERTIES) {
-			if (property in body) {
-				gradeModel.set(property, body[property]);
-			}
-		}
 		try {
-			gradeModel.set('category_id', categoryModel.get('id'));
+			const grade = new Grade();
+			const category = new Category();
+
+			grade.set('category_id', category.get('id'));
+			grade.set('name', null);
+
+			for (const prop of CATEGORY_PROPERTIES) {
+				if (prop in data) {
+					category.set(prop, data[prop]);
+				}
+			}
+
+			for (const prop of GRADE_PROPERTIES) {
+				if (prop in data) {
+					grade.set(prop, data[prop]);
+				}
+			}
 
 			// Insert into categories...
-			await categoryModel.commit(txn);
+			await category.commit(txn);
 
 			// Insert into grades...
-			await gradeModel.commit(txn);
+			await grade.commit(txn);
 
-			const createdCategory = categoryModel.json;
-			createdCategory.grades = [gradeModel.json];
+			const createdCategory = category.json;
+			createdCategory.grades = [grade.json];
 
 			await txn.commit();
 

--- a/lib/controllers/category.js
+++ b/lib/controllers/category.js
@@ -1,7 +1,6 @@
 const api = require('../api');
 const log = require('../logging');
 const errors = require('../errors');
-const {category: {create: NewCategory}, grade: {create: NewGrade}} = require('../models');
 const {category: sanitize, grade: sanitizeGrade} = require('./sanitizers');
 
 module.exports = {
@@ -46,11 +45,21 @@ module.exports = {
 		res.status(200).json(categories);
 	},
 	async create(req, res) {
+		const ALL_PROPERTIES = ['id', 'course_id', 'name', 'weight', 'position', 'user_id', 'course_id', 'grade'];
+		const apiData = {
+			user_id: req.user.id // eslint-disable-line camelcase
+		};
+
+		for (const property of ALL_PROPERTIES) {
+			if (property in req.body) {
+				apiData[property] = req.body[property];
+			}
+		}
 
 		// @todo ensure all types are properly validated in validation - I had to add float checking, so make sure there are no missed cases
 
 		// @todo - add hard limits const categoriesInCourse = await api.category.browse({userID, course: courseID});
-		const response = await api.category.create(req.body);
+		const response = await api.category.create(apiData);
 
 		// @todo add error handling
 		const status = response ? 201 : 500;

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -1,5 +1,4 @@
 const SEMESTER = '2019F'; // @TODO: Dynamically generate this
-const objectID = require('bson-objectid');
 const {user: {response: UserModel}} = require('../models');
 const api = require('../api');
 const {user: sanitize} = require('./sanitizers');
@@ -19,12 +18,18 @@ module.exports = {
 		try {
 			const result = await api.user.update(req.user.id, user, {isNew: false}, txn);
 			// @todo: this should throw an error if validation fails
-			// eslint-disable-next-line camelcase
+			/* eslint-disable camelcase */
 			const course = await api.course.create({user_id: req.user.id, name: 'DEMO 101', semester: SEMESTER}, txn);
+
+			const course_id = course.id;
+			const user_id = req.user.id;
+
+			await api.category.create({course_id, user_id, name: 'Exam 1', weight: 30, position: 100, grade: 90}, txn);
+			await api.category.create({course_id, user_id, name: 'Exam 2', weight: 30, position: 200}, txn);
+			await api.category.create({course_id, user_id, name: 'Final', weight: 40, position: 300}, txn);
+			/* eslint-enable camelcase */
+
 			await txn.commit();
-
-			await api.category.create({id: objectID.generate(), course_id: course.id, name: 'Final', weight: 40, position: 400, user_id: req.user.id});
-
 			const status = result.error ? 500 : 200;
 			return res.status(status).json(result);
 		} catch (error) {


### PR DESCRIPTION
This updates the category.new API and controller layer to what I think it should be.

Sorry if I wasn't clear earlier, the API layer should only get data that's allowed, in the database. Even though the data is considered "safe", we still have that restriction.

I fixed the transaction usage in the user.approve controller method, let me know if there's anything that doesn't make sense.
