### PR TITLE
Increase grade and category limits

### DIFF
--- a/lib/cache/settings.js
+++ b/lib/cache/settings.js
@@ -35,11 +35,20 @@ async function initialize() {
 		updateRequired = true;
 	}
 
-	if (!cache.max_grades_per_course) {
-		log.info('Adding setting: max_grades_per_course');
+	if (!cache.max_categories_per_course) {
+		log.info('Adding setting: max_categories_per_course');
 		await knex('settings').insert({
-			key: 'max_grades_per_course',
-			value: 30
+			key: 'max_categories_per_course',
+			value: 25
+		});
+		updateRequired = true;
+	}
+
+	if (!cache.max_grades_per_category) {
+		log.info('Adding setting: max_grades_per_category');
+		await knex('settings').insert({
+			key: 'max_grades_per_category',
+			value: 40
 		});
 		updateRequired = true;
 	}

--- a/lib/services/permissions/batch-edit-grades.js
+++ b/lib/services/permissions/batch-edit-grades.js
@@ -15,7 +15,7 @@ function responseContainsId(id, response) {
 }
 
 module.exports = permissionWrap(async ({user, category, create, delete: del, ids}) => {
-	const maxGrades = settings.get('max_grades_per_category', 10);
+	const maxGrades = settings.get('max_grades_per_category', 0);
 
 	// CASE: trying to edit more grades than exist in category
 	if (ids.length > maxGrades) {

--- a/lib/services/permissions/batch-edit-grades.js
+++ b/lib/services/permissions/batch-edit-grades.js
@@ -15,7 +15,7 @@ function responseContainsId(id, response) {
 }
 
 module.exports = permissionWrap(async ({user, category, create, delete: del, ids}) => {
-	const maxGrades = settings.get('max_grades_per_category', 25);
+	const maxGrades = settings.get('max_grades_per_category');
 
 	// CASE: trying to edit more grades than exist in category
 	if (ids.length > maxGrades) {
@@ -44,6 +44,7 @@ module.exports = permissionWrap(async ({user, category, create, delete: del, ids
 
 	// CASE: would create too many ny grades
 	if (grades.length + create.length > maxGrades) {
+		debug('too many grades', numberOfGrades);
 		return 403;
 	}
 

--- a/lib/services/permissions/batch-edit-grades.js
+++ b/lib/services/permissions/batch-edit-grades.js
@@ -15,7 +15,7 @@ function responseContainsId(id, response) {
 }
 
 module.exports = permissionWrap(async ({user, category, create, delete: del, ids}) => {
-	const maxGrades = settings.get('max_grades_per_category', 0);
+	const maxGrades = settings.get('max_grades_per_category', 10);
 
 	// CASE: trying to edit more grades than exist in category
 	if (ids.length > maxGrades) {

--- a/lib/services/permissions/batch-edit-grades.js
+++ b/lib/services/permissions/batch-edit-grades.js
@@ -15,7 +15,7 @@ function responseContainsId(id, response) {
 }
 
 module.exports = permissionWrap(async ({user, category, create, delete: del, ids}) => {
-	const maxGrades = settings.get('max_grades_per_category');
+	const maxGrades = settings.get('max_grades_per_category', 0);
 
 	// CASE: trying to edit more grades than exist in category
 	if (ids.length > maxGrades) {

--- a/lib/services/permissions/batch-edit-grades.js
+++ b/lib/services/permissions/batch-edit-grades.js
@@ -44,7 +44,7 @@ module.exports = permissionWrap(async ({user, category, create, delete: del, ids
 
 	// CASE: would create too many ny grades
 	if (grades.length + create.length > maxGrades) {
-		debug('too many grades', numberOfGrades);
+		debug('too many grades', maxGrades);
 		return 403;
 	}
 

--- a/lib/services/permissions/create-category.js
+++ b/lib/services/permissions/create-category.js
@@ -29,7 +29,7 @@ module.exports = permissionWrap(async ({user, course}) => {
 	}
 
 	// CASE: too many categories created
-	if (count >= settings.get('max_categories_per_course')) {
+	if (count >= settings.get('max_categories_per_course', 0)) {
 		debug('too many categories', count);
 		return 403;
 	}

--- a/lib/services/permissions/create-category.js
+++ b/lib/services/permissions/create-category.js
@@ -1,3 +1,4 @@
+const debug = require('ghost-ignition').debug('permissions:create-category');
 const {knex} = require('../../database');
 const settings = require('../../cache/settings');
 const permissionWrap = require('./wrap');

--- a/lib/services/permissions/create-category.js
+++ b/lib/services/permissions/create-category.js
@@ -29,7 +29,7 @@ module.exports = permissionWrap(async ({user, course}) => {
 	}
 
 	// CASE: too many categories created
-	if (count >= settings.get('max_categories_per_course', 10)) {
+	if (count >= settings.get('max_categories_per_course', 0)) {
 		debug('too many categories', count);
 		return 403;
 	}

--- a/lib/services/permissions/create-category.js
+++ b/lib/services/permissions/create-category.js
@@ -29,7 +29,7 @@ module.exports = permissionWrap(async ({user, course}) => {
 	}
 
 	// CASE: too many categories created
-	if (count >= settings.get('max_categories_per_course', 0)) {
+	if (count >= settings.get('max_categories_per_course', 10)) {
 		debug('too many categories', count);
 		return 403;
 	}

--- a/lib/services/permissions/create-category.js
+++ b/lib/services/permissions/create-category.js
@@ -27,9 +27,9 @@ module.exports = permissionWrap(async ({user, course}) => {
 		return 404;
 	}
 
-	// @todo: determine if we plan on having limiting the number of categories
 	// CASE: too many categories created
-	if (false || count >= settings.get('max_categories_per_course')) {
+	if (count >= settings.get('max_categories_per_course')) {
+		debug('too many categories', count);
 		return 403;
 	}
 

--- a/lib/services/permissions/create-course.js
+++ b/lib/services/permissions/create-course.js
@@ -9,7 +9,7 @@ module.exports = permissionWrap(async ({user, semester}) => {
 	const numberOfCourses = queryResponse[0].count;
 
 	// CASE: more courses than allowed in one semester
-	if (numberOfCourses >= settings.get('max_courses_per_semester', 7)) {
+	if (numberOfCourses >= settings.get('max_courses_per_semester', 0)) {
 		return 403;
 	}
 

--- a/lib/services/permissions/create-course.js
+++ b/lib/services/permissions/create-course.js
@@ -9,7 +9,7 @@ module.exports = permissionWrap(async ({user, semester}) => {
 	const numberOfCourses = queryResponse[0].count;
 
 	// CASE: more courses than allowed in one semester
-	if (numberOfCourses >= settings.get('max_courses_per_semester')) {
+	if (numberOfCourses >= settings.get('max_courses_per_semester', 0)) {
 		return 403;
 	}
 

--- a/lib/services/permissions/create-course.js
+++ b/lib/services/permissions/create-course.js
@@ -9,7 +9,7 @@ module.exports = permissionWrap(async ({user, semester}) => {
 	const numberOfCourses = queryResponse[0].count;
 
 	// CASE: more courses than allowed in one semester
-	if (numberOfCourses >= settings.get('max_courses_per_semester', 0)) {
+	if (numberOfCourses >= settings.get('max_courses_per_semester', 7)) {
 		return 403;
 	}
 

--- a/lib/services/permissions/create-grade.js
+++ b/lib/services/permissions/create-grade.js
@@ -26,7 +26,7 @@ module.exports = permissionWrap(async ({user, course, category}) => {
 	}
 
 	// CASE: exceeded grade limit
-	if (numberOfGrades >= settings.get('max_grades_per_category')) {
+	if (numberOfGrades >= settings.get('max_grades_per_category', 0)) {
 		debug('too many grades', numberOfGrades);
 		return 403;
 	}

--- a/lib/services/permissions/create-grade.js
+++ b/lib/services/permissions/create-grade.js
@@ -26,7 +26,7 @@ module.exports = permissionWrap(async ({user, course, category}) => {
 	}
 
 	// CASE: exceeded grade limit
-	if (numberOfGrades >= settings.get('max_grades_per_category', 10)) {
+	if (numberOfGrades >= settings.get('max_grades_per_category', 0)) {
 		debug('too many grades', numberOfGrades);
 		return 403;
 	}

--- a/lib/services/permissions/create-grade.js
+++ b/lib/services/permissions/create-grade.js
@@ -26,7 +26,7 @@ module.exports = permissionWrap(async ({user, course, category}) => {
 	}
 
 	// CASE: exceeded grade limit
-	if (numberOfGrades >= settings.get('max_grades_per_course')) {
+	if (numberOfGrades >= settings.get('max_grades_per_category')) {
 		debug('too many grades', numberOfGrades);
 		return 403;
 	}

--- a/lib/services/permissions/create-grade.js
+++ b/lib/services/permissions/create-grade.js
@@ -26,7 +26,7 @@ module.exports = permissionWrap(async ({user, course, category}) => {
 	}
 
 	// CASE: exceeded grade limit
-	if (numberOfGrades >= settings.get('max_grades_per_category', 0)) {
+	if (numberOfGrades >= settings.get('max_grades_per_category', 10)) {
 		debug('too many grades', numberOfGrades);
 		return 403;
 	}

--- a/test/unit/permissions.js
+++ b/test/unit/permissions.js
@@ -76,13 +76,18 @@ describe('Unit > Permissions', function () {
 
 	describe('Create Course', function () {
 		it('With permission', async function () {
-			const permissions = {user, semester};
-			const {response} = await sendFakeRequest(permissions, createCourse);
-			expect(response.statusCalled).to.be.false;
+			const stub = sinon.stub(settings, 'get').returns(10);
+			try {
+				const permissions = {user, semester};
+				const {response} = await sendFakeRequest(permissions, createCourse);
+				expect(response.statusCalled).to.be.false;
+			} finally {
+				stub.restore();
+			}
 		});
 
 		it('Semester course limit reached', async function () {
-			const stub = sinon.stub(settings, 'get').returns(0);
+			const stub = sinon.stub(settings, 'get').returns(5);
 			try {
 				const permissions = {user, semester};
 				const {response} = await sendFakeRequest(permissions, createCourse);
@@ -98,26 +103,41 @@ describe('Unit > Permissions', function () {
 		const course = testUtils.fixtures.courses[0].id;
 
 		it('With permission', async function () {
-			const permissions = {user, course};
-			const {response} = await sendFakeRequest(permissions, createCategory);
-			expect(response.statusCalled).to.be.false;
+			const stub = sinon.stub(settings, 'get').returns(10);
+			try {
+				const permissions = {user, course};
+				const {response} = await sendFakeRequest(permissions, createCategory);
+				expect(response.statusCalled).to.be.false;
+			} finally {
+				stub.restore();
+			}
 		});
 
 		it('Not permitted', async function () {
-			const permissions = {user: testUtils.fixtures.evilUser.id, course};
-			const {response} = await sendFakeRequest(permissions, createCategory);
-			expect(response.statusCalled).to.be.true;
-			expect(response._statusCode).to.equal(404);
+			const stub = sinon.stub(settings, 'get').returns(10);
+			try {
+				const permissions = {user: testUtils.fixtures.evilUser.id, course};
+				const {response} = await sendFakeRequest(permissions, createCategory);
+				expect(response.statusCalled).to.be.true;
+				expect(response._statusCode).to.equal(404);
+			} finally {
+				stub.restore();
+			}
 		});
 
 		it('Course has no grades', async function () {
-			const permissions = {user, course: testUtils.fixtures.courseWithNoGrades.id};
-			const {response} = await sendFakeRequest(permissions, createCategory);
-			expect(response.statusCalled).to.be.false;
+			const stub = sinon.stub(settings, 'get').returns(10);
+			try {
+				const permissions = {user, course: testUtils.fixtures.courseWithNoGrades.id};
+				const {response} = await sendFakeRequest(permissions, createCategory);
+				expect(response.statusCalled).to.be.false;
+			} finally {
+				stub.restore();
+			}
 		});
 
 		it('Category limit reached', async function () {
-			const stub = sinon.stub(settings, 'get').returns(0);
+			const stub = sinon.stub(settings, 'get').returns(5);
 			try {
 				const permissions = {user, course};
 				const {response} = await sendFakeRequest(permissions, createCategory);
@@ -134,27 +154,37 @@ describe('Unit > Permissions', function () {
 		const category = testUtils.fixtures.categories[0].id;
 
 		it('With permission', async function () {
-			const permissions = {user, course, category};
-			const {response} = await sendFakeRequest(permissions, createGrade);
-			expect(response.statusCalled).to.be.false;
+			const stub = sinon.stub(settings, 'get').returns(10);
+			try {
+				const permissions = {user, course, category};
+				const {response} = await sendFakeRequest(permissions, createGrade);
+				expect(response.statusCalled).to.be.false;
+			} finally {
+				stub.restore();
+			}
 		});
 
 		it('Not permitted', async function () {
-			const permissions = {user: testUtils.fixtures.evilUser.id, course, category};
-			const {response} = await sendFakeRequest(permissions, createGrade);
-			expect(response.statusCalled).to.be.true;
-			expect(response._statusCode).to.equal(404);
+			const stub = sinon.stub(settings, 'get').returns(10);
+			try {
+				const permissions = {user: testUtils.fixtures.evilUser.id, course, category};
+				const {response} = await sendFakeRequest(permissions, createGrade);
+				expect(response.statusCalled).to.be.true;
+				expect(response._statusCode).to.equal(404);
+			} finally {
+				stub.restore();
+			}
 		});
 
 		it('Grade limit reached', async function () {
-			const stub = sinon.stub(settings, 'get').returns(0);
+			const stub = sinon.stub(settings, 'get').returns(5);
 			try {
 				const permissions = {user, course, category};
 				const {response} = await sendFakeRequest(permissions, createGrade);
 				expect(response.statusCalled).to.be.true;
 				expect(response._statusCode).to.equal(403);
 			} finally {
-				stub.reset();
+				stub.restore();
 			}
 		});
 	});


### PR DESCRIPTION
The maximum grade and category limits were somewhat inconsistent in terminology and usage. I've made it so it should makes sense now. I've have also set the limits as such:

- `max_courses_per_semester` = 7 (no change)
- `max_categories_per_course` = 25 (down from 30)
- `max_grades_per_category` = 40

Upped grade max to 40 because of several people's request! I'll also make a frontend PR once this is live.