### PR TITLE
Update semester.delete API to actually delete data and use actions

### DIFF
--- a/lib/api/course.js
+++ b/lib/api/course.js
@@ -27,7 +27,6 @@ module.exports = {
 	async delete(id) {
 		const txn = await knex.transaction();
 		try {
-			// @todo: determine if we need to add the additional where clause - should be handled by permissions?
 			await txn('grades').where('course_id', id).delete();
 
 			const numCategoriesDeleted = await txn('categories').where('course_id', id).delete();

--- a/lib/api/semester.js
+++ b/lib/api/semester.js
@@ -1,13 +1,46 @@
 const {knex} = require('../database');
+const analytics = require('../services/analytics');
+const errors = require('../errors');
 
 module.exports = {
-	delete(options) {
+	async delete(options) {
 		const {semester, user} = options;
+		const txn = await knex.transaction();
+		let numCategoriesDeleted = 0;
+		let numCoursesDeleted = 0;
 
-		return knex('courses').where({
-			user_id: user, // eslint-disable-line camelcase
-			semester: semester.toUpperCase(),
-			status: 1
-		}).update('status', 0);
+		try {
+			const ids = await txn('courses').select('id').where({
+				user_id: user, // eslint-disable-line camelcase
+				semester: semester.toUpperCase(),
+				status: 1
+			});
+
+			for (idObject of ids) {
+				const id = idObject.id;
+				// @todo: determine if we need to add the additional where clause - should be handled by permissions?
+				await txn('grades').where('course_id', id).delete();
+
+				numCategoriesDeleted += await txn('categories').where('course_id', id).delete();
+
+				const localNumCourses = await txn('courses').where({id}).delete();
+
+				// Exactly 1 course must be removed
+				if (localNumCourses !== 1) {
+					throw new errors.InternalServerError({message: 'Failed to remove course'});
+				}
+
+				numCoursesDeleted += localNumCourses;
+			}
+
+			await txn.commit();
+
+			analytics.courseDeleted.add([numCoursesDeleted, numCategoriesDeleted]);
+
+			return true;
+		} catch (error) {
+			await txn.rollback();
+			throw error;
+		}
 	}
 };

--- a/lib/api/semester.js
+++ b/lib/api/semester.js
@@ -15,7 +15,6 @@ module.exports = {
 
 			const ids = idObjects.map(({id}) => id);
 
-			// @todo: determine if we need to add the additional where clause - should be handled by permissions?
 			await txn('grades').whereIn('course_id', ids).delete();
 
 			const numCategoriesDeleted = await txn('categories').whereIn('course_id', ids).delete();

--- a/lib/api/semester.js
+++ b/lib/api/semester.js
@@ -6,34 +6,25 @@ module.exports = {
 	async delete(options) {
 		const {semester, user} = options;
 		const txn = await knex.transaction();
-		let numCategoriesDeleted = 0;
-		let numCoursesDeleted = 0;
 
 		try {
-			const ids = await txn('courses').select('id').where({
+			const idObjects = await txn('courses').select('id').where({
 				user_id: user, // eslint-disable-line camelcase
-				semester: semester.toUpperCase(),
-				status: 1
+				semester: semester.toUpperCase()
 			});
 
-			for (const idObject of ids) {
-				const {id} = idObject;
-				// @todo: determine if we need to add the additional where clause - should be handled by permissions?
-				// eslint-disable-next-line no-await-in-loop
-				await txn('grades').where('course_id', id).delete();
+			const ids = idObjects.map(({id}) => id);
 
-				// eslint-disable-next-line no-await-in-loop
-				numCategoriesDeleted += await txn('categories').where('course_id', id).delete();
+			// @todo: determine if we need to add the additional where clause - should be handled by permissions?
+			await txn('grades').whereIn('course_id', ids).delete();
 
-				// eslint-disable-next-line no-await-in-loop
-				const localNumCourses = await txn('courses').where({id}).delete();
+			const numCategoriesDeleted = await txn('categories').whereIn('course_id', ids).delete();
 
-				// Exactly 1 course must be removed
-				if (localNumCourses !== 1) {
-					throw new errors.InternalServerError({message: 'Failed to remove course'});
-				}
+			const numCoursesDeleted = await txn('courses').whereIn('id', ids).delete();
 
-				numCoursesDeleted += localNumCourses;
+			// At least 1 course must be removed
+			if (numCoursesDeleted < 1) {
+				throw new errors.InternalServerError({message: 'Failed to remove course'});
 			}
 
 			await txn.commit();

--- a/lib/api/semester.js
+++ b/lib/api/semester.js
@@ -16,13 +16,16 @@ module.exports = {
 				status: 1
 			});
 
-			for (idObject of ids) {
-				const id = idObject.id;
+			for (const idObject of ids) {
+				const {id} = idObject;
 				// @todo: determine if we need to add the additional where clause - should be handled by permissions?
+				// eslint-disable-next-line no-await-in-loop
 				await txn('grades').where('course_id', id).delete();
 
+				// eslint-disable-next-line no-await-in-loop
 				numCategoriesDeleted += await txn('categories').where('course_id', id).delete();
 
+				// eslint-disable-next-line no-await-in-loop
 				const localNumCourses = await txn('courses').where({id}).delete();
 
 				// Exactly 1 course must be removed


### PR DESCRIPTION
This updates semester.delete to actually delete courses rather than update the status to 0. 

Things that need to happen:

- Delete all courses and course data in prod db with status of 0 (very important bc this broke the client for me in testing)
- remove status column from db and migrate