### PR TITLE
Add theme override to config

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -14,7 +14,6 @@
       "filename": "content/database.db"
     }
   },
-  "theme": false,
   "domain": false,
   "logging": {
     "level": "info",

--- a/config.example.json
+++ b/config.example.json
@@ -14,6 +14,7 @@
       "filename": "content/database.db"
     }
   },
+  "theme": false,
   "domain": false,
   "logging": {
     "level": "info",

--- a/lib/services/theming.js
+++ b/lib/services/theming.js
@@ -1,3 +1,5 @@
+const config = require('../config');
+
 // @ts-check
 class ThemeService {
 	constructor() {
@@ -16,7 +18,12 @@ class ThemeService {
 	* @returns {string} json blob of theme data
 	*/
 	getThemeForHost(hostname) {
-		const school = hostname.split('.').shift();
+		let school = hostname.split('.').shift();
+
+		if (config.get('theme')) { // Use override if provided
+			school = config.get('theme');
+		}
+
 		if (!this._themes.has(school)) {
 			return this._themes.get('default');
 		}

--- a/lib/services/theming.js
+++ b/lib/services/theming.js
@@ -1,6 +1,6 @@
-const config = require('../config');
-
 // @ts-check
+const OVERRIDE_THEME = 'aggie';
+
 class ThemeService {
 	constructor() {
 		/**
@@ -20,8 +20,8 @@ class ThemeService {
 	getThemeForHost(hostname) {
 		let school = hostname.split('.').shift();
 
-		if (config.get('theme')) { // Use override if provided
-			school = config.get('theme');
+		if (OVERRIDE_THEME) { // Use override if provided
+			school = OVERRIDE_THEME;
 		}
 
 		if (!this._themes.has(school)) {

--- a/lib/services/theming.js
+++ b/lib/services/theming.js
@@ -9,7 +9,7 @@ class ThemeService {
 		* @type {Map<string, string>}
 		*/
 		this._themes = new Map();
-		this._themes.set('default', '{"primary": "#000000", "hover": "#555", "siteNickname": "", "slug": "generic"}');
+		this._themes.set('default', '{"primary": "#000000", "hover": "#555", "siteNickname": "", "imageName": "generic"}');
 		this._themes.set('aggie', '{"primary": "#500000", "hover": "#c00000", "siteNickname": "Aggie", "imageName": "aggie"}');
 	}
 


### PR DESCRIPTION
Adding a theme override to the `config.json` file. Default is false, which is no override. Enter what the subdomain for the specific site would be.