### PR TITLE
Fix singularization in category expansion

### DIFF
--- a/lib/api/category.js
+++ b/lib/api/category.js
@@ -1,5 +1,5 @@
 const debug = require('ghost-ignition').debug('api:category');
-const pluralize = require('pluralize');
+const {singularize} = require('@gradebook/fast-pluralize');
 const {knex} = require('../database');
 const errors = require('../errors');
 const events = require('../events');
@@ -160,7 +160,7 @@ module.exports = {
 		const categoryId = currentCategoryModel.get('id');
 		const txn = await knex.instance.transaction();
 		try {
-			const nameBase = pluralize.singular(currentCategoryModel.get('name'));
+			const nameBase = singularize(currentCategoryModel.get('name'));
 			await knex({txn, table: 'grades', db}).where('category_id', categoryId).update('name', `${nameBase} 1`);
 
 			const newGrade = new Grade();

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@gradebook/express-brute-redis": "0.1.0",
+    "@gradebook/fast-pluralize": "^0.0.1",
     "ajv": "6.11.0",
     "bluebird": "3.7.2",
     "body-parser": "1.19.0",
@@ -44,7 +45,6 @@
     "node-cron": "2.0.3",
     "passport": "0.4.1",
     "passport-google-oauth20": "2.0.0",
-    "pluralize": "8.0.0",
     "sqlite3": "4.1.1",
     "validator": "12.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,6 +171,11 @@
   resolved "https://registry.yarnpkg.com/@gradebook/express-brute-redis/-/express-brute-redis-0.1.0.tgz#b1475fe1eeb0ecd044d383264ff4c50d8deed9df"
   integrity sha512-ow2hetjx2IoUo2MM3mn7XvYLV+DYgGkpqxE0aVy9U3TKs8GeOR2O/7fej0kWae2SiwxbWtBEc91sc+ORb63NvQ==
 
+"@gradebook/fast-pluralize@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@gradebook/fast-pluralize/-/fast-pluralize-0.0.1.tgz#15766452b3b007074c4545ed35c0ee351d545ec4"
+  integrity sha512-U9r+OBO0vvQoW4LAX/1vcXjSqBs7uej5267zLMWo9bnvS6FGm7uTuk+CRZGX9TS+B+jHecMVaFEm8ZVlEjphdw==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -5217,11 +5222,6 @@ plur@^3.0.1:
   integrity sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==
   dependencies:
     irregular-plurals "^2.0.0"
-
-pluralize@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
-  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 pluralize@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
This implements the `@gradebook/fast-pluralize` package to fix the issue with improper singularization on category expansion.