### PR TITLE
✨ add category.contract endpoint

### DIFF
--- a/lib/api/category.js
+++ b/lib/api/category.js
@@ -11,6 +11,9 @@ const MODEL_NAME = 'category';
 
 const baseRead = base.read(MODEL_NAME);
 
+const NO_DB_CONTRACT_QUERY = 'DELETE FROM `grades` WHERE `grades`.`category_id` = ? LIMIT ?;';
+const DB_CONTRACT_QUERY = 'DELETE FROM ??.`grades` WHERE ??.`grades`.`category_id` = ? LIMIT ?;';
+
 module.exports = {
 	browse: (options, db = null) => {
 		const query = knex({db, table: 'categories'}).select('categories.*').orderBy('categories.position');
@@ -175,6 +178,28 @@ module.exports = {
 			analytics.categoryExpanded.add([db, 1]);
 
 			return grades;
+		} catch (error) {
+			await txn.rollback();
+			throw error;
+		}
+	},
+	/**
+	* @param {string} id
+	* @param {number} numGrades
+	* @param {string} db
+	*/
+	async contract(id, numGrades, grade, db = null) {
+		const txn = await knex.instance.transaction();
+		try {
+			const limit = numGrades - 1;
+			const bindings = db ? [db, db, id, limit] : [id, limit];
+			// https://github.com/knex/knex/issues/96
+			await txn.raw(db ? DB_CONTRACT_QUERY : NO_DB_CONTRACT_QUERY, bindings);
+			await knex({txn, table: 'grades', db}).where('category_id', id).update({name: null, grade});
+			const dbGrade = await knex({txn, table: 'grades', db}).where('category_id', id).select('id').first();
+
+			await txn.commit();
+			return dbGrade.id;
 		} catch (error) {
 			await txn.rollback();
 			throw error;

--- a/lib/controllers/category.js
+++ b/lib/controllers/category.js
@@ -137,5 +137,18 @@ module.exports = {
 		}
 
 		res.status(status).json(allGrades);
+	},
+
+	/**
+	* @param {import('../../global').Request} req
+	* @param {import('express').Response} res
+	*/
+	async contract(req, res) {
+		const {queriedData: category} = req;
+		const {grade} = req.body;
+
+		const id = await api.category.contract(category.id, category.grades, grade);
+
+		return res.status(200).json({id, grade, name: null});
 	}
 };

--- a/lib/services/permissions/contract-category.js
+++ b/lib/services/permissions/contract-category.js
@@ -1,0 +1,40 @@
+// @ts-check
+const {knex} = require('../../database');
+const permissionWrap = require('./wrap');
+
+module.exports = permissionWrap(async ({user, objectId: id}, db = null) => {
+	const category = await knex({db, table: 'categories'})
+		.select(['courses.user_id', 'courses.semester', 'categories.*'])
+		.where('categories.id', knex.instance.raw('?', [id]))
+		.count('grades.id as grades')
+		.innerJoin('courses', 'courses.id', 'categories.course_id')
+		.innerJoin('grades', 'grades.category_id', 'categories.id')
+		.first();
+
+	// CASE: category doesn't exist
+	if (!category) {
+		return 404;
+	}
+
+	// CASE: user does not own category
+	if (category.user_id !== user) {
+		return 404;
+	}
+
+	// CASE: category is already contracted
+	if (category.grades <= 1) {
+		return 412;
+	}
+
+	/* @todo
+	// CASE: category is not in current semester
+	if (category.semester !== '2020S') {
+		return 412;
+	}
+	*/
+
+	delete category.semester;
+	delete category.user_id;
+
+	return {status: true, data: category};
+});

--- a/lib/services/permissions/index.js
+++ b/lib/services/permissions/index.js
@@ -14,7 +14,8 @@ const permissions = {
 	deleteCourse: require('./edit-course'),
 	deleteCategory: require('./edit-category'),
 	deleteGrade: require('./edit-grade'),
-	batchEditGrades: require('./batch-edit-grades')
+	batchEditGrades: require('./batch-edit-grades'),
+	contractCategory: require('./contract-category')
 };
 
 module.exports = function findAssociatedPermission(name) {

--- a/lib/services/validation/contract-category.js
+++ b/lib/services/validation/contract-category.js
@@ -1,0 +1,18 @@
+const isObjectID = require('../../utils/object-id-valid');
+const errors = require('../../errors');
+const ajv = require('./schema-validator');
+
+module.exports = function checkForRequiredContractKeys(req, _, next) {
+	ajv.validateSchemeOrDie('category.contract', req.body);
+
+	if (!isObjectID(req.params.id)) {
+		throw new errors.NotFoundError();
+	}
+
+	req.permissions = {
+		user: req.user.id,
+		objectId: req.params.id
+	};
+
+	next();
+};

--- a/lib/services/validation/index.js
+++ b/lib/services/validation/index.js
@@ -16,6 +16,7 @@ const validations = {
 	deleteGrade: require('./for-read-delete'),
 	batchEditGrades: require('./batch-edit-grades'),
 	expandCategory: require('./expand-category'),
+	contractCategory: require('./contract-category'),
 	userSettings: require('./user-settings')
 };
 

--- a/lib/services/validation/schema-validator.js
+++ b/lib/services/validation/schema-validator.js
@@ -11,6 +11,7 @@ const SCHEMAS = [
 	require('./schemas/edit-course.json'),
 	require('./schemas/edit-category.json'),
 	require('./schemas/edit-grade.json'),
+	require('./schemas/contract-category.json'),
 	require('./schemas/batch-edit.json')
 ];
 

--- a/lib/services/validation/schemas/contract-category.json
+++ b/lib/services/validation/schemas/contract-category.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "category.contract",
+  "description": "Contract a category",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["grade"],
+  "properties": {
+    "grade": {
+      "type": ["number", "null"]
+    }
+  }
+}

--- a/lib/web/app.js
+++ b/lib/web/app.js
@@ -116,6 +116,7 @@ module.exports.mount = app => {
 	app.put('/api/v0/categories', validation('createCategory'), permission('createCategory'), wrap(category.create));
 	app.post('/api/v0/category/:id', validation('editCategory'), permission('editCategory'), wrap(category.edit));
 	app.post('/api/v0/category/:id/expand', validation('expandCategory'), permission('editCategory'), wrap(category.expand));
+	app.post('/api/v0/category/:id/contract', validation('contractCategory'), permission('contractCategory'), wrap(category.contract));
 	app.delete('/api/v0/category/:id', validation('deleteCategory'), permission('deleteCategory'), wrap(category.delete));
 
 	app.put('/api/v0/grades', validation('createGrade'), permission('createGrade'), wrap(grade.create));

--- a/test/unit/permissions.js
+++ b/test/unit/permissions.js
@@ -11,6 +11,7 @@ const createGrade = require(`${root}/create-grade`);
 const editCourse = require(`${root}/edit-course`);
 const editCategory = require(`${root}/edit-category`);
 const editGrade = require(`${root}/edit-grade`);
+const contractCategory = require(`${root}/contract-category`);
 
 class FakeResponse {
 	constructor() {
@@ -81,6 +82,7 @@ describe('Unit > Permissions', function () {
 		expect(permissions.deleteCourse, 'deleteCourse').to.equal(editCourse);
 		expect(permissions.deleteCategory, 'deleteCategory').to.equal(editCategory);
 		expect(permissions.deleteGrade, 'deleteGrade').to.equal(editGrade);
+		expect(permissions.contractCategory, 'contractCategory').to.equal(contractCategory);
 	});
 
 	describe('Create Course', function () {
@@ -263,7 +265,7 @@ describe('Unit > Permissions', function () {
 	describe('Edit Grade', function () {
 		const grade = testUtils.fixtures.grades[0].id;
 
-		it('does not exist', async function () {
+		it('Does not exist', async function () {
 			const permissions = {user, objectId: objectID.generate()};
 			try {
 				await sendFakeRequest(permissions, editGrade);
@@ -273,13 +275,13 @@ describe('Unit > Permissions', function () {
 			}
 		});
 
-		it('with permission', async function () {
+		it('With permission', async function () {
 			const permissions = {user, objectId: grade};
 			const {response} = await sendFakeRequest(permissions, editGrade);
 			expect(response.statusCalled).to.be.false;
 		});
 
-		it('no permission', async function () {
+		it('No permission', async function () {
 			const permissions = {user: testUtils.fixtures.evilUser.id, objectId: grade};
 			try {
 				await sendFakeRequest(permissions, editGrade);
@@ -287,6 +289,49 @@ describe('Unit > Permissions', function () {
 			} catch (error) {
 				assertIsNotFoundError(error);
 			}
+		});
+	});
+
+	describe('Contract Category', function () {
+		// Name is Homework
+		const category = testUtils.fixtures.categories[0].id;
+
+		it('Does not exist', async function () {
+			const permissions = {user, objectId: objectID.generate()};
+
+			try {
+				await sendFakeRequest(permissions, contractCategory);
+				expectError();
+			} catch (error) {
+				assertIsNotFoundError(error);
+			}
+		});
+
+		it('With permission', async function () {
+			const permissions = {user, objectId: category};
+			const {response} = await sendFakeRequest(permissions, contractCategory);
+			expect(response.statusCalled).to.be.false;
+		});
+
+		it('No permission', async function () {
+			const permissions = {user: testUtils.fixtures.evilUser.id, objectId: category};
+			try {
+				await sendFakeRequest(permissions, contractCategory);
+				expectError();
+			} catch (error) {
+				assertIsNotFoundError(error);
+			}
+		});
+
+		it('Not expanded', async function () {
+			// Name is Test 1
+			const permissions = {user, objectId: testUtils.fixtures.categories[1].id};
+
+			const {response} = await sendFakeRequest(permissions, contractCategory);
+
+			expect(response.statusCalled).to.be.true;
+			expect(response.endCalled).to.be.true;
+			expect(response._statusCode).to.equal(412);
 		});
 	});
 });

--- a/test/unit/schemas/contract-category.js
+++ b/test/unit/schemas/contract-category.js
@@ -1,0 +1,27 @@
+const schemaValidator = require('../../utils/schema-validator');
+const objSchema = require('../../../lib/services/validation/schemas/object-id.json');
+const schema = require('../../../lib/services/validation/schemas/contract-category.json');
+
+describe('Unit > Schemas > ContractCategory', function () {
+	const {expectInvalid, expectValid} = schemaValidator(schema, [objSchema]);
+
+	it('invalid props', function () {
+		expectInvalid({}, ['keyword', 'required'], 'grade');
+	});
+
+	it('grade', function () {
+		const obj = {grade: 100};
+		const errorProp = ['dataPath', '.grade'];
+
+		expectValid(obj);
+
+		obj.grade = '';
+		expectInvalid(obj, errorProp, 'number');
+
+		obj.grade = true;
+		expectInvalid(obj, errorProp, 'number');
+
+		obj.grade = null;
+		expectValid(obj);
+	});
+});


### PR DESCRIPTION
__As this is an `epic` change, both @ramsays and @joshcosta need to approve the PR__

`POST /api/v0/category/:id/contract`

Accepts: `{grade: number}`
Response: `{id: string, name: null, grade: number}`

The response contains the only grade associated with `category.id` and the updated properties (`name`, `grade`).

This has been a highly requested feature.