### PR TITLE
:building_construction: expose category.dropped_grades (as dropped) CRUD

### DIFF
--- a/lib/api/category.js
+++ b/lib/api/category.js
@@ -10,6 +10,7 @@ const base = require('./base');
 const MODEL_NAME = 'category';
 
 const baseRead = base.read(MODEL_NAME);
+const baseUpdate = base.update(MODEL_NAME);
 
 const NO_DB_CONTRACT_QUERY = 'DELETE FROM `grades` WHERE `grades`.`category_id` = ? LIMIT ?;';
 const DB_CONTRACT_QUERY = 'DELETE FROM ??.`grades` WHERE ??.`grades`.`category_id` = ? LIMIT ?;';
@@ -84,6 +85,9 @@ module.exports = {
 		return response;
 	},
 	async create(data, transaction = null, db = null) {
+		data.dropped_grades = data.dropped;
+		delete data.dropped;
+
 		const CATEGORY_PROPERTIES = ['name', 'weight', 'position', 'course_id'];
 		// @note: a non-expanded category has a grade without a name
 		const GRADE_PROPERTIES = ['course_id', 'user_id', 'grade'];
@@ -129,7 +133,14 @@ module.exports = {
 			throw error;
 		}
 	},
-	update: base.update(MODEL_NAME),
+	update(id, responseInstance, data = {}, transaction, db = null) { // eslint-disable-line default-param-last
+		if ('dropped' in data) {
+			data.dropped_grades = data.dropped; // eslint-disable-line camelcase
+			delete data.dropped;
+		}
+
+		return baseUpdate(id, responseInstance, data, transaction, db);
+	},
 	async delete(category, user, db = null) {
 		const txn = await knex.instance.transaction();
 		try {

--- a/lib/api/category.js
+++ b/lib/api/category.js
@@ -88,7 +88,7 @@ module.exports = {
 		data.dropped_grades = data.dropped; // eslint-disable-line camelcase
 		delete data.dropped;
 
-		const CATEGORY_PROPERTIES = ['name', 'weight', 'position', 'course_id'];
+		const CATEGORY_PROPERTIES = ['name', 'weight', 'position', 'dropped_grades', 'course_id'];
 		// @note: a non-expanded category has a grade without a name
 		const GRADE_PROPERTIES = ['course_id', 'user_id', 'grade'];
 		const txn = transaction || await knex.instance.transaction();

--- a/lib/api/category.js
+++ b/lib/api/category.js
@@ -85,7 +85,7 @@ module.exports = {
 		return response;
 	},
 	async create(data, transaction = null, db = null) {
-		data.dropped_grades = data.dropped;
+		data.dropped_grades = data.dropped; // eslint-disable-line camelcase
 		delete data.dropped;
 
 		const CATEGORY_PROPERTIES = ['name', 'weight', 'position', 'course_id'];

--- a/lib/controllers/category.js
+++ b/lib/controllers/category.js
@@ -104,7 +104,7 @@ module.exports = {
 	*/
 	async edit(req, res) {
 		const response = await api.category.update(req.params.id, req.queriedData, req.body, null, req._table);
-		res.status(200).json(response);
+		res.status(200).json(sanitize(response));
 	},
 	/**
 	* @param {import('../../global').Request} req

--- a/lib/controllers/sanitizers/category.js
+++ b/lib/controllers/sanitizers/category.js
@@ -1,4 +1,5 @@
 module.exports = function sanitizeCategory(modelResponse) {
+	modelResponse.dropped = modelResponse.dropped_grades;
 	delete modelResponse.dropped_grades;
 
 	return modelResponse;

--- a/lib/services/validation/schemas/create-category.json
+++ b/lib/services/validation/schemas/create-category.json
@@ -24,6 +24,18 @@
         }
       ]
     },
+    "dropped": {
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 40
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "position": {
       "type": ["integer", "null"],
       "$comment": "@todo: Position should have a max string length (e.g. 4 numbers)"

--- a/lib/services/validation/schemas/edit-category.json
+++ b/lib/services/validation/schemas/edit-category.json
@@ -23,6 +23,18 @@
         }
       ]
     },
+    "dropped": {
+      "anyOf": [
+        {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 40
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "position": {
       "type": ["integer", "null"]
     }


### PR DESCRIPTION
Resolves #1 

Adding dropped-grades to schema. Does not require a database migration since it already exists, just needs to expose the field in the API and validation.