### PR TITLE
Disallow null grade names

### DIFF
--- a/config.testing.json
+++ b/config.testing.json
@@ -10,6 +10,20 @@
   "logging": {
     "transports": []
   },
+  "rateLimit": {
+    "authenticated": {
+      "lifetime": 1
+    },
+    "batchEditGrades": {
+      "lifetime": 1
+    },
+    "exportData": {
+      "lifetime": 1
+    },
+    "unauthenticated": {
+      "lifetime": 1
+    }
+  },
   "oauth": {
     "id": "lolno",
     "secret": "password"

--- a/lib/controllers/grade.js
+++ b/lib/controllers/grade.js
@@ -51,15 +51,11 @@ module.exports = {
 		const updatedData = {};
 
 		if ('name' in req.body) {
-			updatedData.name = req.body.name;
-
 			if (gradeObject.get('name') === null) {
 				throw new errors.BadRequestError({message: 'cannot set name of category'});
 			}
 
-			if (!req.body.name) {
-				throw new errors.BadRequestError({message: 'cannot remove name of category item'});
-			}
+			updatedData.name = req.body.name;
 		}
 
 		if ('grade' in req.body) {

--- a/lib/services/validation/schemas/batch-edit.json
+++ b/lib/services/validation/schemas/batch-edit.json
@@ -30,7 +30,7 @@
           "name": {
             "minLength": 1,
             "maxLength": 50,
-            "type": ["string", "null"]
+            "type": "string"
           }
         }
       }
@@ -50,7 +50,7 @@
           "name": {
             "minLength": 1,
             "maxLength": 50,
-            "type": ["string", "null"]
+            "type": "string"
           }
         }
       }

--- a/lib/services/validation/schemas/create-grade.json
+++ b/lib/services/validation/schemas/create-grade.json
@@ -11,7 +11,7 @@
     "name": {
       "minLength": 1,
       "maxLength": 50,
-      "type": ["string", "null"]
+      "type": "string"
     },
     "grade": {
       "type": ["number", "null"]

--- a/lib/services/validation/schemas/edit-grade.json
+++ b/lib/services/validation/schemas/edit-grade.json
@@ -12,7 +12,7 @@
     "name": {
       "minLength": 1,
       "maxLength": 50,
-      "type": ["string", "null"]
+      "type": "string"
     },
     "grade": {
       "type": ["number", "null"]

--- a/test/functional/routes.spec.js
+++ b/test/functional/routes.spec.js
@@ -68,7 +68,7 @@ describe('Functional > API Routes', function () {
 					expect(body).to.be.an('array').with.length(14);
 					body.forEach(category => {
 						expect(Object.keys(category)).to.deep.equal(
-							['id', 'course_id', 'name', 'weight', 'position']
+							['id', 'course_id', 'name', 'weight', 'position', 'dropped']
 						);
 					});
 				});

--- a/test/functional/routes.spec.js
+++ b/test/functional/routes.spec.js
@@ -171,9 +171,12 @@ describe('Functional > API Routes', function () {
 				.post(`/api/v0/grade/${id}`)
 				.set('Cookie', testUtils.fixtures.cookies.trusted)
 				.send({name: null})
-				.expect(400)
+				.expect(422)
 				.then(request => {
-					expect(request.body).to.deep.equal({error: 'cannot remove name of category item'});
+					expect(request.body).to.deep.equal({
+						error: 'data.name should be string',
+						context: 'Failed validating payload'
+					});
 				});
 		});
 	});

--- a/test/functional/routes.spec.js
+++ b/test/functional/routes.spec.js
@@ -179,5 +179,38 @@ describe('Functional > API Routes', function () {
 					});
 				});
 		});
+
+		it('/api/v0/category/{id}/batch removing grade name', function () {
+			const categoryId = testUtils.fixtures.categories[0].id;
+			const gradeId = testUtils.fixtures.grades[0].id;
+
+			return supertest(instance)
+				.post(`/api/v0/category/${categoryId}/batch`)
+				.set('Cookie', testUtils.fixtures.cookies.trusted)
+				.send({update: [{id: gradeId, name: null}]})
+				.expect(422)
+				.then(request => {
+					expect(request.body).to.deep.equal({
+						error: 'data.update[0].name should be string',
+						context: 'Failed validating payload'
+					});
+				});
+		});
+
+		it('/api/v0/category/{id}/batch creating grade with no name', function () {
+			const {id} = testUtils.fixtures.categories[0];
+
+			return supertest(instance)
+				.post(`/api/v0/category/${id}/batch`)
+				.set('Cookie', testUtils.fixtures.cookies.trusted)
+				.send({create: [{name: null, grade: 92}]})
+				.expect(422)
+				.then(request => {
+					expect(request.body).to.deep.equal({
+						error: 'data.create[0].name should be string',
+						context: 'Failed validating payload'
+					});
+				});
+		});
 	});
 });

--- a/test/functional/routes.spec.js
+++ b/test/functional/routes.spec.js
@@ -213,4 +213,23 @@ describe('Functional > API Routes', function () {
 				});
 		});
 	});
+
+	describe('PUT data', function () {
+		it('/api/v0/grades where name is null', function () {
+			const course = testUtils.fixtures.courses[0].id;
+			const category = testUtils.fixtures.categories[0].id;
+
+			return supertest(instance)
+				.put('/api/v0/grades')
+				.set('Cookie', testUtils.fixtures.cookies.trusted)
+				.send({category, course, name: null})
+				.expect(422)
+				.then(request => {
+					expect(request.body).to.deep.equal({
+						error: 'data.name should be string',
+						context: 'Failed validating payload'
+					});
+				});
+		});
+	});
 });

--- a/test/functional/routes.spec.js
+++ b/test/functional/routes.spec.js
@@ -162,4 +162,19 @@ describe('Functional > API Routes', function () {
 				.expect(412);
 		});
 	});
+
+	describe('POST data', function () {
+		it('/api/v0/grade/{id} where name is null', function () {
+			const {id} = testUtils.fixtures.grades[0];
+
+			return supertest(instance)
+				.post(`/api/v0/grade/${id}`)
+				.set('Cookie', testUtils.fixtures.cookies.trusted)
+				.send({name: null})
+				.expect(400)
+				.then(request => {
+					expect(request.body).to.deep.equal({error: 'cannot remove name of category item'});
+				});
+		});
+	});
 });

--- a/test/unit/schemas/create-grade.js
+++ b/test/unit/schemas/create-grade.js
@@ -30,7 +30,7 @@ describe('Unit > Schemas > CreateGrade', function () {
 		expectInvalid(obj, errorProp, 'should be string');
 
 		obj.name = null;
-		expectValid(obj);
+		expectInvalid(obj, errorProp, 'should be string');
 
 		obj.name = 'Project 1';
 		expectValid(obj);

--- a/test/unit/schemas/edit-grade.js
+++ b/test/unit/schemas/edit-grade.js
@@ -22,7 +22,7 @@ describe('Unit > Schemas > EditGrade', function () {
 		expectInvalid(obj, errorProp, 'should be string');
 
 		obj.name = null;
-		expectValid(obj);
+		expectInvalid(obj, errorProp, 'should be string');
 
 		obj.name = 'Project 1';
 		expectValid(obj);


### PR DESCRIPTION
Updates category.batch, grade.create, and grade.edit to disallow `name: null` in the payload