### PR TITLE
:sparkles: add `gpaSemester` user setting

### DIFF
--- a/lib/services/validation/user-settings.js
+++ b/lib/services/validation/user-settings.js
@@ -19,7 +19,7 @@ const SETTINGS = {
 	overallGpa: {
 		isValid: value => ((!isNaN(value)) & (value >= 0) & (value <= 5))
 	},
-	gpaUpdatedAt: {
+	gpaSemester: {
 		isValid: semesterCodeIsValid
 	}
 };

--- a/lib/services/validation/user-settings.js
+++ b/lib/services/validation/user-settings.js
@@ -1,4 +1,5 @@
 const errors = require('../../errors');
+const semesterCodeIsValid = require('../../utils/semester-key-valid');
 
 const isBoolean = value => typeof value === 'boolean';
 
@@ -17,6 +18,9 @@ const SETTINGS = {
 	},
 	overallGpa: {
 		isValid: value => ((!isNaN(value)) & (value >= 0) & (value <= 5))
+	},
+	gpaUpdatedAt: {
+		isValid: semesterCodeIsValid
 	}
 };
 


### PR DESCRIPTION
This adds a user setting that stores the latest semester the user modified gpa settings. More info to come in client PR.

Note: Didn't need to add tests because user settings and the semester key validator are already covered.