### PR TITLE
🔧 enable server-side live reloading

### DIFF
--- a/_commands/dev.js
+++ b/_commands/dev.js
@@ -11,7 +11,7 @@ const precheck = require('./_precheck');
 
 const commands = [
 	['Backend Server', 'yarn backend:dev'],
-	['Frontend Builder', 'yarn --cwd lib/frontend/client/ start']
+	['Frontend Builder', 'yarn --cwd lib/frontend/client/ dev']
 ];
 
 async function run() {

--- a/config.example.json
+++ b/config.example.json
@@ -16,6 +16,7 @@
   },
   "domain": false,
   "user event endpoint": false,
+  "live reload": false,
   "logging": {
     "level": "info",
     "rotation": {

--- a/lib/controllers/home.js
+++ b/lib/controllers/home.js
@@ -5,8 +5,8 @@ const themeService = require('../services/theming');
 const {user: {response: UserModel}} = require('../models');
 
 /**
-* @param {import('../../global').Request} req
-* @param {import('express').Response} res
+* @param {boolean} isProduction
+* @returns {(request: import('../../global').Request, response: import('express').Response) => void}
 */
 module.exports.marketing = isProduction => (req, res) => {
 	if (req.user || !isProduction) {

--- a/lib/controllers/home.js
+++ b/lib/controllers/home.js
@@ -1,8 +1,12 @@
 // @ts-check
 const {frontend} = require('../api');
+const config = require('../config');
 const analytics = require('../services/analytics');
 const themeService = require('../services/theming');
 const {user: {response: UserModel}} = require('../models');
+
+const lr = config.get('live reload').toString() === 'true' ?
+	'<script src="/assets/lr.js" type="module"></script>\n' : '';
 
 /**
 * @param {boolean} isProduction
@@ -37,7 +41,10 @@ module.exports.app = async (req, res) => {
 	const sitePayload = `\t<meta name="site-name" value="${encodeURI(theme.metadata.name)}" />`;
 
 	res.send(
-		template.replace('__META_USER_STATE__', userPayload).replace('</head>', `${sitePayload}\n${theme.styles}\n</head>`)
+		template.replace('__META_USER_STATE__', userPayload).replace(
+			'</head>',
+			`${lr}${sitePayload}\n${theme.styles}\n</head>`
+		)
 	);
 
 	if (!req.session.userProfile && req.user) {

--- a/lib/frontend/assets/lr.js
+++ b/lib/frontend/assets/lr.js
@@ -1,0 +1,36 @@
+const SOURCE = '/dev/live-reload';
+const LOG_PREFIX = '[LiveReload] ';
+
+const listener = new EventSource(SOURCE);
+
+const log = (...args) => {
+	if (typeof args[0] === 'string') {
+		args[0] = `${LOG_PREFIX}${args[0]}`;
+	} else {
+		args.unshift(LOG_PREFIX);
+	}
+
+	// eslint-disable-next-line no-console
+	console.log(...args);
+};
+
+listener.addEventListener('open', () => {
+	log('connected');
+});
+
+listener.addEventListener('message', message => {
+	if (message.data === 'hello') {
+		// Noop
+	} else if (message.data === 'change') {
+		log('Time to refresh');
+		window.location.reload();
+	} else {
+		log('Unknown event: %s', message.data);
+	}
+});
+
+listener.addEventListener('error', () => {
+	if (listener.readyState !== listener.OPEN) {
+		log('disconnected');
+	}
+});

--- a/lib/web/index.js
+++ b/lib/web/index.js
@@ -1,5 +1,6 @@
 // @ts-check
 const express = require('express');
+const config = require('../config');
 
 const middlewares = [
 	require('./logging'),
@@ -7,6 +8,12 @@ const middlewares = [
 	require('./update-user-session'),
 	require('./app')
 ];
+
+if (config.get('live reload').toString() === 'true') {
+	middlewares.unshift(null);
+	middlewares[0] = middlewares[1];
+	middlewares[1] = require('./live-reload');
+}
 
 module.exports = () => {
 	const app = express();

--- a/lib/web/live-reload.js
+++ b/lib/web/live-reload.js
@@ -1,0 +1,52 @@
+// @ts-check
+const {resolve} = require('path');
+const chokidar = require('chokidar');
+
+const watcher = chokidar.watch(resolve(__dirname, '../frontend/client/'), {
+	followSymlinks: false,
+	depth: 2,
+	usePolling: false,
+	persistent: true,
+	ignoreInitial: true,
+	ignored: /node_modules|release\/assets/
+});
+
+const clients = new Set();
+
+watcher.on('all', () => {
+	for (const client of clients) {
+		client.write('data: change\n\n');
+	}
+});
+
+// Nodemon
+process.once('SIGUSR2', () => {
+	for (const client of clients) {
+		client.end();
+	}
+
+	process.kill(process.pid, 'SIGUSR2');
+});
+
+/**
+* @param {import('express').Application} app
+*/
+module.exports.mount = app => {
+	app.get('/dev/live-reload', (request, response) => {
+		response.status(200);
+		response.set('connection', 'keep-alive');
+		response.set('content-type', 'text/event-stream');
+		response.set('cache-control', 'no-cache');
+
+		response.write('data: hello\n\n');
+
+		const disconnect = () => {
+			clients.delete(response);
+		};
+
+		response.on('close', disconnect);
+		response.on('finish', disconnect);
+
+		clients.add(response);
+	});
+};

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/express": "4.17.4",
     "@types/express-session": "1.17.0",
     "chai": "4.2.0",
+    "chokidar": "^3.4.0",
     "eslint-plugin-mocha": "6.3.0",
     "execa": "4.0.0",
     "mocha": "7.1.1",
@@ -113,6 +114,12 @@
         "rules": {
           "no-console": "off"
         }
+      },
+      {
+        "files": "lib/frontend/assets/*.js",
+        "envs": [
+          "browser"
+        ]
       }
     ]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,6 +1033,21 @@ chokidar@^3.2.2:
   optionalDependencies:
     fsevents "~2.1.2"
 
+chokidar@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
+  integrity sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chownr@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
@@ -4967,6 +4982,11 @@ picomatch@^2.0.4, picomatch@^2.0.7:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
 
+picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -5248,6 +5268,13 @@ readdirp@~3.3.0:
   integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
   dependencies:
     picomatch "^2.0.7"
+
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+  dependencies:
+    picomatch "^2.2.1"
 
 rechoir@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
The tl;dr is webpack dev server is very heavy, and this server is better. This definitely works, though there might be some edge cases.

Things to do once this is merged:

- [ ] update the cli to spawn client:dev instead of client:start

How to test:

- Add `"live reload": true` to your config, then run `yarn dev`

This PR requires 2 reviewers