### PR TITLE
:recycle: Consolidate auth logic to package

### DIFF
--- a/lib/api/base.js
+++ b/lib/api/base.js
@@ -39,7 +39,7 @@ module.exports = {
 		};
 	},
 
-	create(modelName) {
+	create(modelName, allowSettingId = false) {
 		const Model = models[modelName].create;
 		const eventName = `${modelName}.created`;
 
@@ -48,7 +48,14 @@ module.exports = {
 		}
 
 		return async (data, transaction, db = null) => {
-			const single = new Model();
+			let single;
+
+			if (allowSettingId && Object.hasOwnProperty.call(data, 'id')) {
+				single = new Model(data.id);
+				delete data.id;
+			} else {
+				single = new Model();
+			}
 
 			for (const key in data) {
 				if (Object.hasOwnProperty.call(data, key)) {

--- a/lib/api/user.js
+++ b/lib/api/user.js
@@ -10,7 +10,7 @@ const MODEL_NAME = 'user';
 const baseDelete = base.delete(MODEL_NAME);
 
 module.exports = {
-	create: base.create(MODEL_NAME),
+	create: base.create(MODEL_NAME, true),
 	read: base.read(MODEL_NAME),
 	readGid: async (gid, db = null) => {
 		const user = await knex({db, table: 'users'}).select().where({gid}).first();

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -109,6 +109,7 @@ module.exports = {
 						await txn.rollback();
 
 						const {redirect} = req.session;
+						delete req.session.userProfile;
 						delete req.session.redirect;
 						return res.status(302).redirect(redirect);
 					} catch (error2) {

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -140,6 +140,7 @@ module.exports = {
 			await onUserCreate(profile.gid, user.id, req._table || 'www');
 			await txn.commit();
 			delete req.session.userProfile;
+			req.session.school = req._table;
 
 			if (req.session.redirect) {
 				const {redirect} = req.session;

--- a/lib/models/create-row.js
+++ b/lib/models/create-row.js
@@ -14,12 +14,10 @@ module.exports = function createClassBasedOnSchema(tableName) {
 	const editableColumns = columns.filter(column => column !== 'id');
 
 	return class UnsavedDatabaseRow {
-		constructor() {
+		constructor(id = objectID.generate()) {
 			this.table = tableName;
 			// @todo: convert to private fields when the typescript parser supports it
-			this._databaseObject = {
-				id: objectID.generate()
-			};
+			this._databaseObject = {id};
 		}
 
 		_validate() {

--- a/lib/services/authentication/passport.js
+++ b/lib/services/authentication/passport.js
@@ -1,60 +1,23 @@
 // @ts-check
 const {URL} = require('url');
+const {createProfileHandler, createUserDeserializer, serializeUser} = require('@gradebook/passport-utils');
 const passport = require('passport');
 const Strategy = require('passport-google-oauth20');
-const date = require('dayjs');
 const config = require('../../config');
 const api = require('../../api');
 const {NotFoundError} = require('../../errors');
 
-const domain = (config.get('domain') || '').replace(/^\./, '');
-
-/**
- * @param {import('../../../global').Request} req
- * @param {void} _
- * @param {void} __
- * @param {import('passport').Profile} profile
- * @param {(error, body) => void} callback
- */
-async function handleProfile(req, _, __, profile, callback) {
-	let user = null;
-
-	try {
-		user = await api.user.readGid(profile.id, req._table);
-	} catch (error) {
-		if (!(error instanceof NotFoundError)) {
-			throw error;
-		}
+const handleNotFoundError = error => {
+	if (error instanceof NotFoundError) {
+		return null;
 	}
 
-	if (user) {
-		return callback(null, user);
-	}
+	throw error;
+};
 
-	const {id: gid, emails, displayName, name: {givenName: firstName, familyName: lastName}} = profile;
-	let firstNameFallback = displayName.slice(0, displayName.indexOf(' '));
-	let lastNameFallback = displayName.slice(displayName.indexOf(' ') + 1);
-
-	if (!firstNameFallback || !lastNameFallback) {
-		firstNameFallback = 'Student';
-		lastNameFallback = '';
-	}
-
-	req.session.userProfile = {
-		gid,
-		firstName: firstName || firstNameFallback,
-		lastName: lastName || lastNameFallback,
-		email: emails[0].value,
-		isNew: true,
-		// https://github.com/tgriesser/knex/issues/2649
-		settings: JSON.stringify({
-			tour: false,
-			previous_notification: date().format('YYYY-MM-DDTHH:mm:ss.000-06:00') // eslint-disable-line camelcase
-		})
-	};
-
-	callback(null, {});
-}
+const handleProfile = createProfileHandler(
+	(gid, table) => api.user.readGid(gid, table).catch(handleNotFoundError)
+);
 
 function addStrategy() {
 	const clientID = config.get('oauth:id');
@@ -75,60 +38,12 @@ function addStrategy() {
 module.exports = {
 	init() {
 		addStrategy();
-		passport.serializeUser(
-			/** @param {import('../../../global').Request} request */
-			(request, deserializationProfile, cb) => {
-				const profile = request.session.userProfile || deserializationProfile;
-
-				if (!profile.id) {
-					return cb(null, `gid:${profile.gid}`);
-				}
-
-				cb(null, `${request._table}:${profile.id}`);
-			}
+		passport.serializeUser(serializeUser);
+		passport.deserializeUser(
+			createUserDeserializer(
+				(id, table) => api.user.read(id, table).catch(handleNotFoundError),
+				config.get('domain')
+			)
 		);
-
-		// @todo: Make this work normally
-		// The issue I'm running into is in the case of users that have not created their account.
-		// We don't have an id to use as the deserialization token, so we use the next best thing
-		// (gid). However, gid isn't indexed in the database so performance will be notably worse.
-		// There's a high probability that this user will be logged in indefinitely, meaning every
-		// one of those requests will use an index-free search. We need to determine if passport
-		// supports updating the user serialization token that's not really hacky.
-		passport.deserializeUser(async (req, _id, cb) => {
-			let apiRequest;
-			// @NOTE: don't worry about bson object-id collisions between schools because fuck it
-			let school;
-			let id = _id;
-
-			if (_id.includes(':')) {
-				[school, id] = _id.split(':');
-			}
-
-			if (school === 'gid') {
-				if (req.session.userProfile) {
-					return cb(null, {});
-				}
-
-				apiRequest = api.user.readGid(id, req._table);
-			} else if (domain && school !== 'null' && school !== req._table) {
-				req._passportRedirect = `//${school}.${domain}/my/`;
-				return cb(null, {});
-			} else {
-				apiRequest = api.user.read(id, req._table);
-			}
-
-			try {
-				const user = await apiRequest;
-				cb(null, user);
-			} catch (error) {
-				// CASE: user deleted their account
-				if (error instanceof NotFoundError) {
-					return cb(null, null);
-				}
-
-				cb(error);
-			}
-		});
 	}
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@gradebook/express-brute-redis": "0.1.0",
     "@gradebook/fast-pluralize": "0.0.1",
+    "@gradebook/passport-utils": "0.1.0",
     "ajv": "6.12.0",
     "bluebird": "3.7.2",
     "body-parser": "1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,6 +144,14 @@
   resolved "https://registry.yarnpkg.com/@gradebook/fast-pluralize/-/fast-pluralize-0.0.1.tgz#15766452b3b007074c4545ed35c0ee351d545ec4"
   integrity sha512-U9r+OBO0vvQoW4LAX/1vcXjSqBs7uej5267zLMWo9bnvS6FGm7uTuk+CRZGX9TS+B+jHecMVaFEm8ZVlEjphdw==
 
+"@gradebook/passport-utils@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@gradebook/passport-utils/-/passport-utils-0.1.0.tgz#6eb62b3d0b190c7f0b6d5dd5ec2fb1b8ffadfc62"
+  integrity sha512-XlT0lazhDukOcG8eBITJ84AEQ8OAYWeYRn46LVnyL78lUKTWsc4c9z9jCo+TUI5nvETjV0h170HA65yzSiFt9g==
+  dependencies:
+    bson-objectid "^1.3.1"
+    dayjs "^1.8.28"
+
 "@gradebook/together@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@gradebook/together/-/together-0.1.0.tgz#63d14a59733679ebe252e6dbed7376defecfddf6"
@@ -837,6 +845,11 @@ bson-objectid@1.3.0:
   resolved "https://registry.yarnpkg.com/bson-objectid/-/bson-objectid-1.3.0.tgz#f0f4c7c949fece975f12790510d75d7fe39fb456"
   integrity sha512-YcB+lRJEEEIcHNLKyhmHujW7OCVE3+xr9IpEhlprBZnXgF3hqeePeexIsAaOtu1SbkgZRlJVUxvYZ3ngUOyIew==
 
+bson-objectid@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/bson-objectid/-/bson-objectid-1.3.1.tgz#11e4ce4c3419161fd388113781bb62c1dfbce34b"
+  integrity sha512-eQBNQXsisEAXlwiSy8zRNZdW2xDBJaEVkTPbodYR9hGxxtE548Qq7ilYOd8WAQ86xF7NRUdiWSQ1pa/TkKiE2A==
+
 buf-compare@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a"
@@ -1410,6 +1423,11 @@ dayjs@1.8.23:
   version "1.8.23"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.23.tgz#07b5a8e759c4d75ae07bdd0ad6977f851c01e510"
   integrity sha512-NmYHMFONftoZbeOhVz6jfiXI4zSiPN6NoVWJgC0aZQfYVwzy/ZpESPHuCcI0B8BUMpSJQ08zenHDbofOLKq8hQ==
+
+dayjs@^1.8.28:
+  version "1.8.28"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.28.tgz#37aa6201df483d089645cb6c8f6cef6f0c4dbc07"
+  integrity sha512-ccnYgKC0/hPSGXxj7Ju6AV/BP4HUkXC2u15mikXT5mX9YorEaoi1bEKOmAqdkJHN4EEkmAf97SpH66Try5Mbeg==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
refs gradebook/utils#51

Things to test:

 - [x] New account with HostMatching
 - [x] Existing account with HostMatching
 - [x] Visiting the wrong site with HostMatching
 - [x] New account without HostMatching
 - [x] Existing account with HostMatching

---

 - [x] Logging In
 - [x] Logging Out
 - [x] Making 3 changes (doesn't matter what, 1 would probably be fine as well)

If you're up to it, also check what the session data is each time
 - [x] New users should have `userProfile`, and the serialized profile should be `__school__:{id}`
 - [x] Just created users *should not* have `userProfile` but should have `school`
 - [x] Returning users should only have the serialized profile

I can't test creating a new user (no integration) at the moment, but I highly suspect that session cleanup is broken, and passport-utils cannot handle authenticating newly approved users.