### PR TITLE
:bug: fix sql join order to prevent stats failure

### DIFF
--- a/lib/utils/compute-statistics.js
+++ b/lib/utils/compute-statistics.js
@@ -79,11 +79,11 @@ module.exports = async function runStatistics(fullDate, db = null) {
 
 		knex({db, table: 'categories'})
 			.count('categories.id as totalCategories')
-			.innerJoin('users', qb => {
-				qb.on('courses.user_id', 'users.id').andOnNotIn('users.id', ignoredUsers);
-			})
 			.innerJoin('courses', qb => {
 				qb.on('courses.id', 'categories.course_id').andOn('courses.semester', SEMESTER);
+			})
+			.innerJoin('users', qb => {
+				qb.on('courses.user_id', 'users.id').andOnNotIn('users.id', ignoredUsers);
 			})
 			.first(),
 


### PR DESCRIPTION
Addresses issue that popped up in dev. The fix is flipping the execution order of the joins so that a reference to the `courses` table exists before trying to use it. 

I just need a once-over review to verify that this shouldn't change the end result of the query.

> [2020-06-23 23:58:00] ERROR Failed to insert statistics for "husker":
[2020-06-23 23:58:00] ERROR select count(`categories`.`id`) as `totalCategories` from `husker`.`categories` inner join `husker`.`users` on `courses`.`user_id` = `users`.`id` and 1 = 0 inner join `husker`.`courses` on `courses`.`id` = `categories`.`course_id` and `courses`.`semester` = '2020U' limit 1 - ER_BAD_FIELD_ERROR: Unknown column 'courses.user_id' in 'on clause'
select count(`categories`.`id`) as `totalCategories` from `husker`.`categories` inner join `husker`.`users` on `courses`.`user_id` = `users`.`id` and 1 = 0 inner join `husker`.`courses` on `courses`.`id` = `categories`.`course_id` and `courses`.`semester` = '2020U' limit 1 - ER_BAD_FIELD_ERROR: Unknown column 'courses.user_id' in 'on clause'
Error Code:
    ER_BAD_FIELD_ERROR
Error: ER_BAD_FIELD_ERROR: Unknown column 'courses.user_id' in 'on clause'