### PR TITLE
bump knex

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ghost-ignition": "4.2.2",
     "got": "11.5.2",
     "ioredis": "4.17.3",
-    "knex": "0.21.5",
+    "knex": "0.21.6",
     "lodash.get": "4.4.2",
     "mysql": "2.18.1",
     "node-cron": "2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3729,10 +3729,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-knex@0.21.5:
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.21.5.tgz#c4be1958488f348aed3510aa4b7115639ee1bd01"
-  integrity sha512-cQj7F2D/fu03eTr6ZzYCYKdB9w7fPYlvTiU/f2OeXay52Pq5PwD+NAkcf40WDnppt/4/4KukROwlMOaE7WArcA==
+knex@0.21.6:
+  version "0.21.6"
+  resolved "https://registry.yarnpkg.com/knex/-/knex-0.21.6.tgz#3e80ae38199c41e2dfe7d1d1a38470b1de1c93e7"
+  integrity sha512-gFB2q4MamYCEqzCPNgK7DMcyyAxoHhhSDnPsNDJo50Gor5ibI2n5bNRW768IG5S06k6nE3Gik5/kcoTmbsYbZw==
   dependencies:
     colorette "1.2.1"
     commander "^5.1.0"


### PR DESCRIPTION
no issue

This fixes the really annoying FS warning when running migrations. It's more painful when running a staging environment where you can have 6+ messages each time the process restarts