### PR TITLE
✨ support escaped courses

### DIFF
--- a/lib/services/validation/create-course.js
+++ b/lib/services/validation/create-course.js
@@ -2,26 +2,48 @@ const settings = require('../settings');
 const errors = require('../../errors');
 const ajv = require('./schema-validator');
 
+const context = 'Validate course create';
+
 module.exports = function checkForRequiredKeys(req, _) {
 	ajv.validateSchemeOrDie('course.create', req.body);
 
-	// If invalid JSON is sent we catch when JSON.parse() fails and throw an error
-	let parsedCutoffs = {};
-	try {
-		parsedCutoffs = JSON.parse(req.body.course.cutoffs);
-	} catch {
-		throw new errors.ValidationError({context: 'cutoffs are not valid JSON'});
-	}
+	if (req.query.type === 'partial') {
+		// CASE: The course is declared to be partial and must have an empty cutoffs object.
+		if (req.body.course.cutoffs !== '{}') {
+			throw new errors.ValidationError({
+				context,
+				message: 'partial courses must have empty cutoffs object'
+			});
+		}
+	} else if (req.query.type === 'guided' || req.query.type === 'import' || req.query.type === undefined) {
+		// CASE: Courses that do not include a query.type are treated as guided, the strictest schema.
+		let parsedCutoffs = {};
+		// If invalid JSON is sent we catch when JSON.parse() fails and throw an error
+		try {
+			parsedCutoffs = JSON.parse(req.body.course.cutoffs);
+		} catch {
+			throw new errors.ValidationError({
+				context,
+				message: 'cutoffs are not valid JSON'
+			});
+		}
 
-	// Validate cutoffs separately from the rest of the course since they had to be parsed first
-	ajv.validateSchemeOrDie('course.cutoffs', parsedCutoffs);
+		// Validate cutoffs separately from the rest of the course since they had to be parsed first
+		ajv.validateSchemeOrDie('course.cutoffs', parsedCutoffs);
+	} else {
+		// CASE: An invalid query.type was presented.
+		throw new errors.ValidationError({
+			context,
+			message: 'query.type must be `guided`, `partial`, or undefined'
+		});
+	}
 
 	const maxCategories = settings.get('max_categories_per_course', 10);
 	const maxGradesPerCategory = settings.get('max_grades_per_category', 10);
 
 	if (req.body.categories.length > maxCategories) {
 		throw new errors.ValidationError({
-			context: 'Validate course create',
+			context,
 			message: `Course has too many categories, max is ${maxCategories}`
 		});
 	}
@@ -29,7 +51,7 @@ module.exports = function checkForRequiredKeys(req, _) {
 	for (const category of req.body.categories) {
 		if (category.numGrades > maxGradesPerCategory) {
 			throw new errors.ValidationError({
-				context: 'Validate course create',
+				context,
 				message: `At least one category in course has too many grades, max is ${maxGradesPerCategory}`
 			});
 		}

--- a/lib/services/validation/schemas/legacy-create-course.json
+++ b/lib/services/validation/schemas/legacy-create-course.json
@@ -21,7 +21,7 @@
     },
     "cutoffs": {
       "type": "string",
-      "minLength": 10,
+      "minLength": 0,
       "maxLength": 200
     }
   }

--- a/test/unit/validation.spec.js
+++ b/test/unit/validation.spec.js
@@ -151,6 +151,9 @@ describe('Unit > Validation', function () {
 
 	describe('Create Course', function () {
 		const createRequest = () => ({
+			query: {
+				type: 'guided'
+			},
 			body: {
 				course: {
 					name: 'ECEN 482',
@@ -163,6 +166,56 @@ describe('Unit > Validation', function () {
 					{name: 'Expanded', weight: 60, position: 200, numGrades: 3, dropped: 1}
 				]
 			}, params: {id: '5dc10582a8109cd864bd8a13'}, user: {id: '5dc1069b2ff198252ca3b596'}
+		});
+
+		describe('Only allows empty cutoffs with query type partial', function () {
+			it('Empty cutoffs fails with guided', function () {
+				const req = createRequest();
+				req.body.course.cutoffs = JSON.stringify({});
+
+				try {
+					validations.createCourse(req, null);
+					expectError();
+				} catch (error) {
+					expect(error.message).to.equal('data must NOT have fewer than 4 items');
+				}
+			});
+
+			it('Empty cutoffs is allowed with partial', function () {
+				const req = createRequest();
+				req.query.type = 'partial';
+				req.body.course.cutoffs = JSON.stringify({});
+
+				const stub = sinon.stub(settings, 'get').returns(10);
+
+				validations.createCourse(req, null);
+				stub.restore();
+			});
+
+			it('Cutoffs are required with no query type', function () {
+				const req = createRequest();
+				req.body.course.cutoffs = JSON.stringify({});
+				delete req.query.type;
+
+				try {
+					validations.createCourse(req, null);
+					expectError();
+				} catch (error) {
+					expect(error.message).to.equal('data must NOT have fewer than 4 items');
+				}
+			});
+
+			it('Cutoffs are not allowed with partial', function () {
+				const req = createRequest();
+				req.query.type = 'partial';
+
+				try {
+					validations.createCourse(req, null);
+					expectError();
+				} catch (error) {
+					expect(error.message).to.equal('partial courses must have empty cutoffs object');
+				}
+			});
 		});
 
 		describe('Only allows valid number of categories', function () {


### PR DESCRIPTION
Allows courses marked as escaped to include an empty cutoffs object. The request query parameter "type" is used to mark courses as escaped.


req.query.type options:
- "partial": Escaped from course creator. Must have empty cutoffs object.
- "guided": Finished course creator. Cutoffs validated as usual.
- "import": Course is an import. Cutoffs validated as usual.
- else: Cutoffs still validated as usual.


Unit tests check that escaped courses must have an empty cutoffs object, and all other courses must have actual cutoffs.


Meta:
- 1 reviewer
- rebase