### PR TITLE
Improvements to settings service

### DIFF
--- a/lib/services/permissions/batch-edit-grades.js
+++ b/lib/services/permissions/batch-edit-grades.js
@@ -17,7 +17,7 @@ function responseContainsId(id, response) {
 }
 
 module.exports = permissionWrap(async ({user, category, create, delete: del, ids}, db = null) => {
-	const maxGrades = settings.get('max_grades_per_category', 10);
+	const maxGrades = settings.get('max_grades_per_category');
 
 	// CASE: trying to edit more grades than exist in category
 	if (ids.length > maxGrades) {

--- a/lib/services/permissions/create-category.js
+++ b/lib/services/permissions/create-category.js
@@ -40,7 +40,7 @@ module.exports = permissionWrap(async ({user, course}, db = null) => {
 	}
 
 	// CASE: too many categories created
-	if (count >= settings.get('max_categories_per_course', 10)) {
+	if (count >= settings.get('max_categories_per_course')) {
 		debug('too many categories', count);
 		return 403;
 	}

--- a/lib/services/permissions/create-course.js
+++ b/lib/services/permissions/create-course.js
@@ -18,7 +18,7 @@ module.exports = permissionWrap(async ({user, semester}, db = null) => {
 	const numberOfCourses = queryResponse[0].count;
 
 	// CASE: more courses than allowed in one semester
-	if (numberOfCourses >= settings.get('max_courses_per_semester', 7)) {
+	if (numberOfCourses >= settings.get('max_courses_per_semester')) {
 		return 403;
 	}
 

--- a/lib/services/permissions/create-grade.js
+++ b/lib/services/permissions/create-grade.js
@@ -37,7 +37,7 @@ module.exports = permissionWrap(async ({user, course, category}, db = null) => {
 	}
 
 	// CASE: exceeded grade limit
-	if (numberOfGrades >= settings.get('max_grades_per_category', 10)) {
+	if (numberOfGrades >= settings.get('max_grades_per_category')) {
 		debug('too many grades', numberOfGrades);
 		return 403;
 	}

--- a/lib/services/settings/base-adapter.js
+++ b/lib/services/settings/base-adapter.js
@@ -1,23 +1,18 @@
 // @ts-check
 const randomLetters = require('../../security/random-letters');
 
-/* eslint-disable camelcase */
-const DEFAULT_SETTINGS = {
-	session_secret: randomLetters(40),
-	max_courses_per_semester: 7,
-	max_categories_per_course: 25,
-	max_grades_per_category: 40,
-};
-/* eslint-enable camelcase */
-
 /**
  * @abstract
  */
 module.exports = class AbstractSettingsStore {
-	// @todo: make this a property when eslint supports it
-	static get DEFAULT_SETTINGS() {
-		return DEFAULT_SETTINGS;
-	}
+	/* eslint-disable camelcase */
+	static DEFAULT_SETTINGS = {
+		session_secret: randomLetters(40),
+		max_courses_per_semester: 7,
+		max_categories_per_course: 25,
+		max_grades_per_category: 40,
+	};
+	/* eslint-enable camelcase */
 
 	constructor() {
 		/**

--- a/lib/services/settings/base-adapter.js
+++ b/lib/services/settings/base-adapter.js
@@ -95,8 +95,8 @@ module.exports = class AbstractSettingsStore {
 
 	/**
 	 * Get a setting property
-	 * @param {string} key the setting to lookup
 	 * @param {any} defaultValue fallback if the setting doesn't exist
+	 * @param {keyof AbstractSettingsStore.DEFAULT_SETTINGS} key the setting to lookup
 	 */
 	get(key, defaultValue) {
 		const value = this._cache.get(key);

--- a/lib/services/settings/base-adapter.js
+++ b/lib/services/settings/base-adapter.js
@@ -8,7 +8,7 @@ module.exports = class AbstractSettingsStore {
 	/* eslint-disable camelcase */
 	static DEFAULT_SETTINGS = {
 		session_secret: randomLetters(40),
-		max_courses_per_semester: 7,
+		max_courses_per_semester: 8,
 		max_categories_per_course: 25,
 		max_grades_per_category: 40,
 	};

--- a/lib/services/settings/base-adapter.js
+++ b/lib/services/settings/base-adapter.js
@@ -95,11 +95,10 @@ module.exports = class AbstractSettingsStore {
 
 	/**
 	 * Get a setting property
-	 * @param {any} defaultValue fallback if the setting doesn't exist
 	 * @param {keyof AbstractSettingsStore.DEFAULT_SETTINGS} key the setting to lookup
 	 */
-	get(key, defaultValue) {
+	get(key) {
 		const value = this._cache.get(key);
-		return value === undefined ? defaultValue : value;
+		return value === undefined ? AbstractSettingsStore.DEFAULT_SETTINGS[key] : value;
 	}
 };

--- a/lib/services/settings/index.js
+++ b/lib/services/settings/index.js
@@ -1,10 +1,13 @@
 // @ts-check
 const config = require('../../config');
 
+// @ts-expect-error since we're not using esm (where we can use async/await for module loading),
+// the types can be a bit off
 module.exports.init = async () => {
 	const adapterFile = String(config.get('redis')) === 'true' ? './redis-adapter' : './sql-adapter';
 	const Adapter = require(adapterFile);
 
+	/** @type {import('./base-adapter')} */
 	const singleton = new Adapter();
 	await singleton.init();
 
@@ -12,6 +15,7 @@ module.exports.init = async () => {
 	return singleton;
 };
 
+// @ts-expect-error see line 4
 module.exports.get = () => {
 	throw new Error('Settings service has not been initialized');
 };

--- a/lib/services/validation/create-category.js
+++ b/lib/services/validation/create-category.js
@@ -8,7 +8,7 @@ module.exports = function checkForRequiredCategoryKeys(request, _) {
 	// @ts-ignore
 	ajv.validateSchemeOrDie('category.create', request.body);
 
-	if (request.body.grades.length > settings.get('max_grades_per_category', 10)) {
+	if (request.body.grades.length > settings.get('max_grades_per_category')) {
 		throw new errors.ValidationError({message: 'Too many grades'});
 	}
 

--- a/lib/services/validation/shared/create-course.js
+++ b/lib/services/validation/shared/create-course.js
@@ -31,8 +31,8 @@ module.exports.validateCutoffs = cutoffs => {
 };
 
 module.exports.validateCategoryLimits = categoryList => {
-	const maxCategories = settings.get('max_categories_per_course', 10);
-	const maxGradesPerCategory = settings.get('max_grades_per_category', 10);
+	const maxCategories = settings.get('max_categories_per_course');
+	const maxGradesPerCategory = settings.get('max_grades_per_category');
 
 	if (categoryList.length > maxCategories) {
 		throw new errors.ValidationError({


### PR DESCRIPTION
- Centralize default values to abstract settings store
- Improve types
- Sync max course count with what we have in prod

@joshcosta - Ramsay and I have updated our settings table, you need to do so as well. Pick your query:

```sql
DELETE FROM settings WHERE key != "session_secret"; -- On init, adapter will populate defaults that are missing
-- OR
update settings set value=8 where key="max_courses_per_semester";
```

Reviewers: 1 + 1 (1 needed for merge, but everyone should review it)
Merge Type: rebase