### PR TITLE
🔧update api method signatures to require database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,22 +40,34 @@ jobs:
         REQUIRE_BRANCH: release
   integration:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: testing
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
         node-version: lts/*
         cache: yarn
-    - name: Install dependencies and setup
+    - name: Configure Dependencies
       run: |
+        yarn install --frozen-lockfile
         mkdir -p $(yarn cache dir)
         mkdir -p lib/frontend/client/release
         echo '<title>gradebook</title>' > lib/frontend/client/release/index.html
-        yarn install --frozen-lockfile
-        NODE_ENV=testing yarn knex migrate:latest
-        node scripts/initialize-test-db.js
+    - name: Start MySQL
+      run: |
+        sudo /etc/init.d/mysql start
+        sudo mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'toor'"
+    - name: Bootstrap Database
+      run: |
+        # Do not initialize the fake host with seed data so we can make sure host matching is respected
+        database__connection__database=host_fake yarn knex migrate:latest
+        database__connection__database=host_real yarn knex migrate:latest
+        database__connection__database=host_real node scripts/initialize-test-db.js
     - name: Functional Tests
       run: yarn test:functional
+      env:
+        database__connection__database: host_real
     - name: Trigger Webhook
       run: yarn release-utils hook
       env:

--- a/lib/api/base.js
+++ b/lib/api/base.js
@@ -62,7 +62,7 @@ module.exports = {
 
 		// JSDoc doesn't support extended generics (e.g. T extends object)
 		// @ts-ignore
-		return async (filterOptions = {}, db = null, txn = null) => {
+		return async (filterOptions = {}, db, txn = null) => { // eslint-disable-line default-param-last
 			assertBrowseFiltersContents(filterOptions, false);
 			const filters = applyFilters(filterOptions);
 			assertBrowseFiltersContents(filterOptions, true);
@@ -81,7 +81,7 @@ module.exports = {
 	create(modelName, allowSettingId = false) {
 		const Model = models[modelName].create;
 
-		return async ({data, txn, db = null}) => {
+		return async ({data, txn, db}) => {
 			let single;
 
 			if (allowSettingId && Object.hasOwnProperty.call(data, 'id')) {
@@ -111,7 +111,7 @@ module.exports = {
 		const table = getTable(dataType);
 		const serializeType = serializers[dataType].unsnake;
 
-		return async ({id, db = null}) => {
+		return async ({id, db}) => {
 			const response = await applyFilters(knex({table, db}).select('*').where({id}).first());
 			if (!response) {
 				throw new NotFoundError({message: `${dataType} not found`});
@@ -129,7 +129,7 @@ module.exports = {
 	update(modelName) {
 		const Model = models[modelName].response;
 
-		return async ({model, txn, data = {}, db = null}) => {
+		return async ({model, txn, data = {}, db}) => {
 			if (!(model instanceof Model)) {
 				throw new TypeError('responseInstance not instanceof ModelResponse');
 			}
@@ -167,7 +167,7 @@ module.exports = {
 	delete(dataType, key = 'id') {
 		const table = getTable(dataType);
 
-		return async ({id, txn, db = null}) => {
+		return async ({id, txn, db}) => {
 			const query = {[key]: id};
 			const numberDeleted = await knex({table, db, txn}).where(query).delete();
 

--- a/lib/api/category.js
+++ b/lib/api/category.js
@@ -20,7 +20,7 @@ module.exports = {
 		semesters?: string[];
 	}>}
 	*/
-	async browse(options, db = null, txn = null) {
+	async browse(options, db, txn = null) {
 		base.assertBrowseFiltersContents(options, false);
 
 		/** @type {import('knex').Knex.QueryBuilder} */
@@ -90,7 +90,7 @@ module.exports = {
 	},
 	read: base.read(MODEL_NAME),
 	/** @param {import('./base-types').CreateOptions<any>} context */
-	async create({data, txn: transaction = null, db = null}) {
+	async create({data, db, txn: transaction = null}) {
 		const {user, course} = data;
 		let {grades} = data;
 		delete data.user;
@@ -151,9 +151,9 @@ module.exports = {
 	 * @param {string} category
 	 * @param {string} user
 	 * @param {string} db
-	 * @param {import('knex').Knex.Transaction} byoTxn
+	 * @param {import('knex').Knex.Transaction} [byoTxn]
 	*/
-	async delete(category, user, db = null, byoTxn = null) {
+	async delete(category, user, db, byoTxn = null) {
 		const txn = byoTxn ?? await knex.instance.transaction();
 		try {
 			// eslint-disable-next-line camelcase

--- a/lib/api/course.js
+++ b/lib/api/course.js
@@ -47,13 +47,13 @@ const applyBrowseFilters = options => {
 
 /**
  * @param {import('./course-types').ICategoryConfig[]} categories
- * @param {import('knex').Knex.Transaction} txn
  * @param {string | null} db
+ * @param {import('knex').Knex.Transaction} txn
  * @param {import('./category')} categoryApi
  * @param {string} courseId
  * @param {string} userId
  */
-const mapCreateCategoriesToPromises = (categories, txn, db, categoryApi, courseId, userId) => categories.map(config => {
+const mapCreateCategoriesToPromises = (categories, db, txn, categoryApi, courseId, userId) => categories.map(config => {
 	/** @type {import('./course-types').IInternalCategory} */
 	// @ts-expect-error grades won't exist here and we won't clone the object just to make that happen
 	const category = config;
@@ -79,7 +79,7 @@ const mapCreateCategoriesToPromises = (categories, txn, db, categoryApi, courseI
 		delete config.numGrades;
 	}
 
-	return categoryApi.create({data: config, txn, db});
+	return categoryApi.create({data: config, db, txn});
 });
 
 module.exports = {
@@ -89,7 +89,7 @@ module.exports = {
 	 * @param {string} user
 	 * @param {string} db
 	 */
-	async browseSemesters(user, db = null) {
+	async browseSemesters(user, db) {
 		const response = await knex({table: 'courses', db}).distinct('semester').where('user_id', user);
 		return response.map(({semester}) => semester);
 	},
@@ -99,17 +99,17 @@ module.exports = {
 	 * @param {import('knex').Knex.Transaction} [transaction]
 	 * @param {string} db
 	 */
-	async create(data, transaction, db = null) {
+	async create(data, db, transaction) {
 		const txn = transaction ?? await knex.instance.transaction();
 
 		try {
 			data.course.user = data.user;
 
-			const course = await baseCreate({data: data.course, txn, db});
+			const course = await baseCreate({data: data.course, db, txn});
 			const categories = await Promise.all(mapCreateCategoriesToPromises(
 				data.categories,
-				txn,
 				db,
+				txn,
 				require('./category'),
 				course.id,
 				data.user,
@@ -144,8 +144,8 @@ module.exports = {
 		try {
 			const categories = await Promise.all(mapCreateCategoriesToPromises(
 				data.categories,
-				txn,
 				db,
+				txn,
 				require('./category'),
 				data.course,
 				data.user,
@@ -174,14 +174,14 @@ module.exports = {
 	 * @param {import('./base-types').DeleteOptions} context
 	 * @param {string} user
 	 */
-	async delete({id, db = null}, user) {
+	async delete({id, db}, user) {
 		const txn = await knex.instance.transaction();
 		try {
-			await knex({txn, table: 'grades', db}).where('course_id', id).delete();
+			await knex({db, txn, table: 'grades'}).where('course_id', id).delete();
 
-			const numberCategoriesDeleted = await knex({txn, db, table: 'categories'}).where('course_id', id).delete();
+			const numberCategoriesDeleted = await knex({db, txn, table: 'categories'}).where('course_id', id).delete();
 
-			const numberCoursesDeleted = await knex({txn, db, table: 'courses'}).where({id}).delete();
+			const numberCoursesDeleted = await knex({db, txn, table: 'courses'}).where({id}).delete();
 
 			// Exactly 1 course must be removed
 			if (numberCoursesDeleted !== 1) {

--- a/lib/api/grade.js
+++ b/lib/api/grade.js
@@ -72,7 +72,7 @@ module.exports = {
 	update: base.update(MODEL_NAME),
 	delete: base.delete(MODEL_NAME),
 	/** @param {import('./base-types').MultiDeleteOptions} context */
-	async deleteMultiple({ids, txn, db = null}) {
+	async deleteMultiple({ids, txn, db}) {
 		const response = await knex({txn, db, table: 'grades'}).whereIn('id', ids).delete().catch(error => {
 			throw new errors.InternalServerError({err: error});
 		});

--- a/lib/api/semester.js
+++ b/lib/api/semester.js
@@ -8,7 +8,7 @@ module.exports = {
 	/**
 	 * @param {{semester: string; user: string; db: string}} context
 	 */
-	async delete({semester, user, db = null}) {
+	async delete({semester, user, db}) {
 		const txn = await knex.instance.transaction();
 
 		try {

--- a/lib/api/user.js
+++ b/lib/api/user.js
@@ -20,14 +20,14 @@ const api = {
 	/**
 	 * @param {IImportCourse} course
 	 * @param {string} user
-	 * @param {import('knex').Knex.Transaction} txn
 	 * @param {string} db
+	 * @param {import('knex').Knex.Transaction} txn
 	 */
-	async _importCourse(course, user, txn, db) {
+	async _importCourse(course, user, db, txn) {
 		const courseApi = require('./course');
 		const {categories} = course;
 		delete course.categories;
-		await courseApi.create({user, course, categories}, txn, db);
+		await courseApi.create({user, course, categories}, db, txn);
 	},
 	create: base.create(MODEL_NAME, true),
 	read: base.read(MODEL_NAME, applyFilters),
@@ -42,18 +42,18 @@ const api = {
 	},
 	update: base.update(MODEL_NAME),
 	/** @param {import('./base-types').MinimumMutableOptions & {id: Gradebook.Request['user']}} context */
-	async delete({id: user, db = null, txn: _txn = null}) {
+	async delete({id: user, db, txn: _txn = null}) {
 		const txn = _txn || await knex.instance.transaction();
-		await knex({txn, table: 'grades', db}).where('user_id', user.id).delete();
+		await knex({db, txn, table: 'grades'}).where('user_id', user.id).delete();
 
 		// https://github.com/tgriesser/knex/issues/873
-		const categoryCount = await knex({txn, db, table: 'categories'})
-			.whereIn('course_id', knex({txn, db, table: 'courses'}).where('user_id', user.id).select('id'))
+		const categoryCount = await knex({db, txn, table: 'categories'})
+			.whereIn('course_id', knex({db, txn, table: 'courses'}).where('user_id', user.id).select('id'))
 			.delete();
 
-		const courseCount = await knex({txn, db, table: 'courses'}).where('user_id', user.id).delete();
+		const courseCount = await knex({db, txn, table: 'courses'}).where('user_id', user.id).delete();
 
-		await baseDelete({id: user.id, txn, db});
+		await baseDelete({id: user.id, db, txn});
 
 		if (!_txn) {
 			await txn.commit();
@@ -75,14 +75,14 @@ const api = {
 	 * @param {string} db
 	 * @param {import('knex').Knex.Transaction} byoTxn
 	 */
-	async export(user, db = null, byoTxn = null) {
+	async export(user, db, byoTxn = null) {
 		const txn = byoTxn ?? await knex.instance.transaction();
 		try {
-			const courses = await knex({txn, table: 'courses', db}).select('*').where('user_id', user);
+			const courses = await knex({db, txn, table: 'courses'}).select('*').where('user_id', user);
 			const courseIDs = courses.map(({id}) => id);
 
-			const categories = await knex({txn, table: 'categories', db}).select('*').whereIn('course_id', courseIDs);
-			const grades = await knex({txn, table: 'grades', db})
+			const categories = await knex({db, txn, table: 'categories'}).select('*').whereIn('course_id', courseIDs);
+			const grades = await knex({db, txn, table: 'grades'})
 				.select('*').whereIn('course_id', courseIDs).where('user_id', user);
 
 			if (!byoTxn) {
@@ -119,7 +119,7 @@ const api = {
 			}
 
 			const createdUser = await api.create({data: import_.user, db, txn});
-			await Promise.all(import_.courses.map(course => api._importCourse(course, createdUser.id, txn, db)));
+			await Promise.all(import_.courses.map(course => api._importCourse(course, createdUser.id, db, txn)));
 
 			if (!txn_) {
 				await txn_.commit();

--- a/lib/controllers/course.js
+++ b/lib/controllers/course.js
@@ -25,7 +25,7 @@ module.exports = {
 			user: request.user.id,
 			course: request.body.course,
 			categories: request.body.categories,
-		}, null, request._table);
+		}, request._table);
 
 		response.context = {
 			statusCode: returnedImport.error ? 500 : 201,

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -166,7 +166,7 @@ module.exports = {
 			let user;
 
 			try {
-				user = await api.user.create({data: profile, txn, db: database});
+				user = await api.user.create({data: profile, db: database, txn});
 			} catch (error) {
 				if (request.session.redirect && error.code === 'ER_DUP_ENTRY') {
 					try {
@@ -196,7 +196,7 @@ module.exports = {
 				// @todo: this should throw an error if validation fails
 				const course = convertHashToCourse(request.query.import.toString());
 				course.user = user.id;
-				await api.course.create(course, txn, database);
+				await api.course.create(course, database, txn);
 			}
 
 			await onUserCreate(profile.gid, user.id, request._table || 'www');

--- a/scripts/initialize-test-db.js
+++ b/scripts/initialize-test-db.js
@@ -2,6 +2,7 @@
 const path = require('path');
 /* eslint-disable-next-line import/no-unassigned-import */
 require('../test/global.js'); // Update env
+const config = require('../test/utils/test-config.js');
 const {fixtures} = require('../test/fixtures/example-data');
 
 const root = path.resolve(__dirname, '../');
@@ -11,7 +12,7 @@ const {migrator, knex} = require('../lib/database');
 
 let log = (...args) => console.log(...args);
 
-if (process.env.CI === 'true') {
+if (config.isCI) {
 	log = () => false; // Noop fixture creation logs for CI
 }
 

--- a/test/functional/api.spec.js
+++ b/test/functional/api.spec.js
@@ -4,6 +4,7 @@ const api = require('../../lib/api');
 const exportSerializer = require('../../lib/services/serializers/export-data');
 const getGoldenExport = require('../fixtures/functional-user-export');
 const prepareExport = require('../utils/prepare-export');
+const testConfig = require('../utils/test-config');
 
 const DEFAULT_CUTOFFS = JSON.stringify([{
 	name: 'A',
@@ -19,7 +20,7 @@ const DEFAULT_CUTOFFS = JSON.stringify([{
 	cutoff: 60,
 }]);
 
-const db = undefined;
+const db = testConfig.TEST_DATABASE;
 
 /**
  * @param {import('knex').Knex.Transaction} txn
@@ -129,7 +130,7 @@ describe('Functional > API E2E', function () {
 	before(async function () {
 		const ignoredUsers = require('../../lib/services/ignored-users');
 		await ignoredUsers.init(require('../../lib/config'), require('../../lib/database/knex'));
-		ignoredUsers._users.set(undefined, new Set());
+		ignoredUsers._users.set(db, new Set());
 	});
 
 	it('Browse, Create, Delete', async function () {

--- a/test/functional/api.spec.js
+++ b/test/functional/api.spec.js
@@ -21,11 +21,14 @@ const DEFAULT_CUTOFFS = JSON.stringify([{
 
 const db = undefined;
 
+/**
+ * @param {import('knex').Knex.Transaction} txn
+ */
 async function seed(txn) {
 	const user = await api.user.create({
 		data: {gid: 10_000_000_000_001, firstName: 'Integration', email: 'integration@gbdev.cf'},
-		txn,
 		db,
+		txn,
 	});
 
 	// #region Create first course
@@ -62,7 +65,7 @@ async function seed(txn) {
 			numGrades: 1,
 			dropped: null,
 		}],
-	}, txn);
+	}, db, txn);
 	// #endregion
 
 	// #region Create second course
@@ -105,7 +108,7 @@ async function seed(txn) {
 			numGrades: 1,
 			dropped: null,
 		}],
-	}, txn);
+	}, db, txn);
 	// #endregion
 
 	return {user, firstCourse, secondCourse};
@@ -125,7 +128,8 @@ async function getExport(user, txn) {
 describe('Functional > API E2E', function () {
 	before(async function () {
 		const ignoredUsers = require('../../lib/services/ignored-users');
-		return ignoredUsers.init(require('../../lib/config'), require('../../lib/database/knex'));
+		await ignoredUsers.init(require('../../lib/config'), require('../../lib/database/knex'));
+		ignoredUsers._users.set(undefined, new Set());
 	});
 
 	it('Browse, Create, Delete', async function () {
@@ -135,6 +139,7 @@ describe('Functional > API E2E', function () {
 
 			// #region Create and delete grade
 			const testGrade = await api.grade.create({
+				db,
 				txn,
 				data: {
 					user: user.id,
@@ -142,10 +147,9 @@ describe('Functional > API E2E', function () {
 					course: firstCourse.course.id,
 					grade: 92,
 				},
-				db,
 			});
 
-			expect(await api.grade.delete({id: testGrade.id, txn, db})).to.be.ok;
+			expect(await api.grade.delete({id: testGrade.id, db, txn})).to.be.ok;
 			// #endregion
 
 			// #region Create and delete category
@@ -165,8 +169,8 @@ describe('Functional > API E2E', function () {
 						grade: null,
 					}],
 				},
-				txn,
 				db,
+				txn,
 			});
 
 			expect(await api.category.delete(testCategory.id, user.id, db, txn)).to.be.ok;

--- a/test/functional/routes.spec.js
+++ b/test/functional/routes.spec.js
@@ -5,6 +5,8 @@ const nock = require('nock');
 const makeApp = require('../utils/app');
 const testUtils = require('../utils');
 
+const {TEST_HOST_NAME} = testUtils.config;
+
 describe('Functional > API Routes', function () {
 	let instance;
 
@@ -19,6 +21,7 @@ describe('Functional > API Routes', function () {
 	it('unauthenticated', function () {
 		return supertest(instance)
 			.get('/api/v0/me')
+			.set('host', TEST_HOST_NAME)
 			.expect(401);
 	});
 
@@ -26,6 +29,7 @@ describe('Functional > API Routes', function () {
 		it('/my/', function () {
 			return supertest(instance)
 				.get('/my/')
+				.set('host', TEST_HOST_NAME)
 				.expect('content-type', /text\/html/)
 				.expect(200)
 				.expect(/<title>gradebook<\/title>/i);
@@ -48,6 +52,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.get('/api/v0/me')
+				.set('host', TEST_HOST_NAME)
 				.set('cookie', testUtils.fixtures.cookies.trusted)
 				.expect(200)
 				.expect(({body}) => {
@@ -59,6 +64,7 @@ describe('Functional > API Routes', function () {
 		it('/api/v0/courses', function () {
 			return supertest(instance)
 				.get('/api/v0/courses')
+				.set('host', TEST_HOST_NAME)
 				.set('cookie', testUtils.fixtures.cookies.trusted)
 				.expect(200)
 				.expect(({body}) => {
@@ -74,6 +80,7 @@ describe('Functional > API Routes', function () {
 		it('/api/v0/categories', function () {
 			return supertest(instance)
 				.get('/api/v0/categories')
+				.set('host', TEST_HOST_NAME)
 				.set('cookie', testUtils.fixtures.cookies.trusted)
 				.expect(200)
 				.expect(({body}) => {
@@ -89,6 +96,7 @@ describe('Functional > API Routes', function () {
 		it('/api/v0/grades', function () {
 			return supertest(instance)
 				.get('/api/v0/grades')
+				.set('host', TEST_HOST_NAME)
 				.set('cookie', testUtils.fixtures.cookies.trusted)
 				.expect(200)
 				.expect(({body}) => {
@@ -109,6 +117,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.get(`/api/v0/course/${course.id}`)
+				.set('host', TEST_HOST_NAME)
 				.set('cookie', testUtils.fixtures.cookies.trusted)
 				.expect(200)
 				.expect(({body}) => {
@@ -126,6 +135,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.get(`/api/v0/category/${category.id}`)
+				.set('host', TEST_HOST_NAME)
 				.set('cookie', testUtils.fixtures.cookies.trusted)
 				.expect(200)
 				.expect(({body}) => {
@@ -144,6 +154,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.get(`/api/v0/grade/${grade.id}`)
+				.set('host', TEST_HOST_NAME)
 				.set('cookie', testUtils.fixtures.cookies.trusted)
 				.expect(200)
 				.expect(({body}) => {
@@ -154,6 +165,7 @@ describe('Functional > API Routes', function () {
 		it('/api/v0/core-data', function () {
 			return supertest(instance)
 				.get('/api/v0/core-data')
+				.set('host', TEST_HOST_NAME)
 				.set('cookie', testUtils.fixtures.cookies.trusted)
 				.expect(200)
 				.expect(({body}) => {
@@ -182,6 +194,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.post(`/api/v0/grade/${id}`)
+				.set('host', TEST_HOST_NAME)
 				.set('Cookie', testUtils.fixtures.cookies.trusted)
 				.send({name: null})
 				.expect(422)
@@ -199,6 +212,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.post(`/api/v0/category/${categoryId}/batch`)
+				.set('host', TEST_HOST_NAME)
 				.set('Cookie', testUtils.fixtures.cookies.trusted)
 				.send({update: [{id: gradeId, name: null}]})
 				.expect(422)
@@ -215,6 +229,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.post(`/api/v0/category/${id}/batch`)
+				.set('host', TEST_HOST_NAME)
 				.set('Cookie', testUtils.fixtures.cookies.trusted)
 				.send({create: [{name: null, grade: 92}]})
 				.expect(422)
@@ -240,6 +255,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.put('/api/v0/courses')
+				.set('host', TEST_HOST_NAME)
 				.set('Cookie', testUtils.fixtures.cookies.trusted)
 				.send({course, categories})
 				.expect(422)
@@ -257,6 +273,7 @@ describe('Functional > API Routes', function () {
 
 			return supertest(instance)
 				.put('/api/v0/grades')
+				.set('host', TEST_HOST_NAME)
 				.set('Cookie', testUtils.fixtures.cookies.trusted)
 				.send({category, course, name: null})
 				.expect(422)
@@ -273,6 +290,7 @@ describe('Functional > API Routes', function () {
 		it('/api/v0/semester/{semester} when the semester does not exist', function () {
 			return supertest(instance)
 				.del('/api/v0/semester/2000F')
+				.set('host', TEST_HOST_NAME)
 				.set('Cookie', testUtils.fixtures.cookies.trusted)
 				.expect(404);
 		});

--- a/test/global.js
+++ b/test/global.js
@@ -12,3 +12,29 @@ const semesterService = require('@gradebook/time').semester.data;
 
 semesterService.activeSemester = '2019S';
 semesterService.allowedSemesters = ['2019S'];
+
+// Configure the config based on the environment
+const config = require('./utils/test-config');
+
+// When running Integration tests in CI, use mysql with host matching
+if (config.TEST_DATABASE) {
+	const config = require('../lib/config.js');
+	if (config.get('database:client') !== 'mysql') {
+		config.set('database', {
+			asyncStackTraces: true,
+			client: 'mysql',
+			connection: {
+				user: 'root',
+				password: 'toor',
+				database: process.env.database__connection__database ?? config.TEST_DATABASE,
+			},
+		});
+	}
+
+	config.set('hostMatching', {
+		enabled: true,
+		hosts: {
+			[config.FUNCTIONAL_TEST_HOST_NAME]: config.FUNCTIONAL_TEST_DATABASE_NAME,
+		},
+	});
+}

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+	config: require('./test-config'),
 	expectError: require('./expect-error'),
 	fixtures: require('../fixtures/example-data'),
 };

--- a/test/utils/schema-validator.js
+++ b/test/utils/schema-validator.js
@@ -1,4 +1,5 @@
 const AJV = require('ajv').default;
+const testConfig = require('./test-config.js');
 
 module.exports = function createSchemaValidator(schema, additionalSchemas = []) {
 	const ajv = new AJV();
@@ -12,7 +13,7 @@ module.exports = function createSchemaValidator(schema, additionalSchemas = []) 
 		},
 
 		expectInvalid(payload, kv = [], messageMatch = '', logError = false) {
-			if ('CI' in process.env) {
+			if (testConfig.isCI) {
 				expect(logError, 'SchemaValidation: logError is a *debug tool* and should not be used in tests').to.not.be.ok;
 			}
 

--- a/test/utils/test-config.js
+++ b/test/utils/test-config.js
@@ -1,0 +1,12 @@
+const isCI = process.env.CI === 'true';
+const isFunctionalTest = process.env.TEST_NAME === 'integration';
+const FUNCTIONAL_TEST_DATABASE_NAME = 'host_real';
+
+module.exports = {
+	isCI,
+	isFunctionalTest,
+	FUNCTIONAL_TEST_DATABASE_NAME,
+	FUNCTIONAL_TEST_DEFAULT_DATABASE: 'host_fake',
+	TEST_DATABASE: isCI && isFunctionalTest ? FUNCTIONAL_TEST_DATABASE_NAME : undefined,
+	TEST_HOST_NAME: 'host-a.gbdev.cf',
+};


### PR DESCRIPTION
closes #190

- database no longer defaults to null in any api calls
- method signature is updated to always have database first and then txn

reviewers: 1 + 1