### PR TITLE
✨ add initial support for shrink (course-search) integration

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -15,6 +15,7 @@
       "filename": "content/database.db"
     }
   },
+  "gateway": null,
   "domain": ".gbdev.cf",
   "ignoredUsers": [],
   "user event endpoint": false,

--- a/lib/controllers/course.js
+++ b/lib/controllers/course.js
@@ -1,5 +1,7 @@
 // @ts-check
+const {setTimeout} = require('timers/promises');
 const api = require('../api');
+const shrink = require('../services/shrink.js');
 const log = require('../logging');
 
 module.exports = {
@@ -26,6 +28,17 @@ module.exports = {
 			course: request.body.course,
 			categories: request.body.categories,
 		}, request._table);
+
+		if (request.query.type === 'shared' && request.query.slug) {
+			const slug = Array.isArray(request.query.slug) ? request.query.slug[0] : request.query.slug;
+			// We want the shrink request to complete, but we don't want to delay the response here.
+			// If the shrink request takes longer than the timeout, we hope that it completes, but if it's
+			// faster than the timeout, we guarantee it completed.
+			await Promise.race([
+				setTimeout(150),
+				shrink.markAsUsed(slug).catch(error => log.error(error)),
+			]);
+		}
 
 		response.context = {
 			statusCode: returnedImport.error ? 500 : 201,

--- a/lib/controllers/home.js
+++ b/lib/controllers/home.js
@@ -9,6 +9,8 @@ const schoolConfigService = require('../services/school-config');
 const {user: {response: UserModel}} = require('../models');
 const sanitize = require('../services/serializers/user');
 const appleMeta = require('../utils/apple-meta');
+const shrinkService = require('../services/shrink.js');
+const logging = require('../logging.js');
 
 const liveReload = String(config.get('live reload')) === 'true'
 	? '<script src="/assets/lr.js" type="module"></script>' : '';
@@ -70,6 +72,25 @@ module.exports.app = async (request, response) => {
 	additionalMetadata += schoolConfigService.getSchoolConfig(request._domain).head + '\n';
 	// Apple device-specific tags
 	additionalMetadata += appleMeta(request);
+
+	if (request.path.includes('/import') && request.query.slug) {
+		const slug = Array.isArray(request.query.slug) ? request.query.slug[0] : request.query.slug;
+
+		if (slug.length <= 40) {
+			try {
+				const course = await shrinkService.read(slug);
+				if (course.error) {
+					throw new Error(`Message from shrink: ${course.error}`);
+				}
+
+				additionalMetadata += `<meta name="x-slug-payload" value="${encodeURI(course)}" />\n`;
+			} catch (error) {
+				error.context = error.message;
+				error.message = 'Failed reading data from shrink';
+				logging.warn(error);
+			}
+		}
+	}
 
 	// User state (can be empty if they're not logged in)
 	const safeUserState = encodeURI(JSON.stringify(sanitize(user.session || '{}')));

--- a/lib/services/internal-auth.js
+++ b/lib/services/internal-auth.js
@@ -1,0 +1,6 @@
+const {AuthManager} = require('@gradebook/client-auth');
+const config = require('../config.js');
+
+const gateway = config.get('gateway');
+
+module.exports = gateway ? new AuthManager(gateway, [['shrink']]) : null;

--- a/lib/services/shrink.js
+++ b/lib/services/shrink.js
@@ -1,0 +1,46 @@
+// @ts-check
+/** @type {import('node-fetch')['default']} */
+// @ts-expect-error
+const fetch = require('node-fetch');
+const authManager = require('./internal-auth');
+
+const SERVICE_NAME = 'shrink';
+
+if (authManager) {
+	module.exports = {
+		/**
+		 * @param {string} slug
+		 */
+		async read(slug) {
+			const [resolution, fetchOptions] = await authManager.getRequestInfo(SERVICE_NAME);
+			const url = `http://${resolution.ip}:${resolution.port}/api/v0/slug/${slug}`;
+			return fetch(url, fetchOptions).then(response => response.json());
+		},
+
+		/**
+		 * @param {string} slug
+		 */
+		async markAsUsed(slug) {
+			const [resolution, fetchOptions] = await authManager.getRequestInfo(SERVICE_NAME);
+			fetchOptions.method = 'post';
+			fetchOptions.body = JSON.stringify({slug});
+
+			const url = `http://${resolution.ip}:${resolution.port}/api/v0/increment-popularity`;
+			return fetch(url, fetchOptions).then(response => response.json());
+		},
+	};
+} else {
+	module.exports = {
+		/**
+		 * @param {string} slug
+		 */
+		async read(slug) {
+			throw new Error(`Cannot read slug ${slug} because gateway is not enabled`);
+		},
+
+		/**
+		 * @param {string} _
+		 */
+		async markAsUsed(_) {},
+	};
+}

--- a/lib/services/shrink.js
+++ b/lib/services/shrink.js
@@ -22,10 +22,11 @@ if (authManager) {
 		 */
 		async markAsUsed(slug) {
 			const [resolution, fetchOptions] = await authManager.getRequestInfo(SERVICE_NAME);
+			fetchOptions.headers['content-type'] = 'application/json';
 			fetchOptions.method = 'post';
 			fetchOptions.body = JSON.stringify({slug});
 
-			const url = `http://${resolution.ip}:${resolution.port}/api/v0/increment-popularity`;
+			const url = `http://${resolution.ip}:${resolution.port}/api/v0/slug/increase-popularity`;
 			return fetch(url, fetchOptions).then(response => response.json());
 		},
 	};

--- a/lib/services/validation/create-course.js
+++ b/lib/services/validation/create-course.js
@@ -31,7 +31,12 @@ module.exports = function checkForRequiredKeys(request, _) {
 				message: 'partial courses must have empty cutoffs object',
 			});
 		}
-	} else if (request.query.type === 'guided' || request.query.type === 'import' || request.query.type === undefined) {
+	} else if (
+		request.query.type === 'guided'
+		|| request.query.type === 'import'
+		|| request.query.type === 'shared'
+		|| request.query.type === undefined
+	) {
 		courseCreateHelpers.validateCutoffs(request.body.course.cutoffs);
 	} else {
 		// CASE: An invalid query.type was presented.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@gradebook/client-auth": "^0.2.0",
     "@gradebook/course-serializer": "0.2.6",
     "@gradebook/express-brute-redis": "0.1.0",
     "@gradebook/fast-pluralize": "0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,6 +235,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@gradebook/client-auth@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@gradebook/client-auth/-/client-auth-0.2.0.tgz#b23b9ca4a5a119a0d8e3b3040b6830d759b69beb"
+  integrity sha512-rbX7GeJRpoooVTk7sA83O8189CbG91bl7NTXhay+An1ezPdHFECxHdn+Ibwlrht2Mtn96CV32NsLSTEcfZKpIw==
+  dependencies:
+    node-fetch "^2.0.0"
+
 "@gradebook/core-developer-tools@0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@gradebook/core-developer-tools/-/core-developer-tools-0.1.3.tgz#0d2a45cee7da07b0e909bdd45ce58de04cf7bb04"
@@ -4667,6 +4674,13 @@ node-cron@3.0.0:
   integrity sha512-DDwIvvuCwrNiaU7HEivFDULcaQualDv7KoNlB/UU1wPW0n1tDEmBJKhEIE6DlF2FuoOHcNbLJ8ITL2Iv/3AWmA==
   dependencies:
     moment-timezone "^0.5.31"
+
+node-fetch@^2.0.0:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@^2.6.1:
   version "2.6.5"


### PR DESCRIPTION
To test:

1. Add a resolver in gateway for shrink
2. Add a client in shrink for server, with permission to access shrink
3. Update your server config to have `"gateway": "http://{client_id}:{client_secret}@{gateway_ip}:{gateway_port}"`
4. Start gateway and shrink
5. Go to `{server}/my/import?slug=abcd`
6. ~~Note: Shrink does not have support for returning slug payloads yet. E2E integration will happen later.~~ in progress