### PR TITLE
🏗️ use JSON redirect instead of HTTP redirect for `/me` API endpoint

### DIFF
--- a/lib/controllers/authentication/with-user.js
+++ b/lib/controllers/authentication/with-user.js
@@ -33,7 +33,13 @@ const redirectUser = (request, response, next) => {
 		// @todo: add a tsconfig that specifies what libs are being used
 		// @ts-ignore
 		const redirect = new URL(request.originalUrl, request._passportRedirect.replace('//', `${request.protocol}://`));
-		return response.status(302).redirect(redirect.href);
+		if (request.path === '/api/v0/me') {
+			response.status(200).json({redirect: redirect.href});
+		} else {
+			response.status(302).redirect(redirect.href);
+		}
+
+		return;
 	}
 
 	next();


### PR DESCRIPTION
refs gradebook/engineering#77

Example:
1. User visits a URL but is not authenticated (e.g. `https://aggie.gradebook.app/my/dashboard`)
2. Internally, the user is redirected to `/login`
3. The user logs in to an account associated with another school (e.g. `the`)
4. Internally, the client fetches `/api/v0/me`
5. Current behavior: server redirects to e.g. `https://the.gradebook.app/api/v0/me`
6. This is a cross-origin request, so the browser sends an OPTIONS request to `https://the.gradebook.app/api/v0/me`
7. We explicitly don't allow cors between subdomains to limit unintended attack surfaces &rarr; request fails
8. Since the request failed, nothing changes

Ideally, we would use `fetch('/api/v0/me', {redirect: 'manual'})`, but the response will be an [`opaqueredirect`](https://developer.mozilla.org/en-US/docs/Web/API/Response/type) so we're not allowed to know of the redirect.

Thus, the workaround is to provide a JSON-based redirect, and let the client handle it