### PR TITLE
Add backend support for Kangaroo mode

### DIFF
--- a/lib/services/validation/user-settings.js
+++ b/lib/services/validation/user-settings.js
@@ -28,7 +28,7 @@ const settings = {
 	redirectFromHome: {
 		isValid: isBoolean,
 	},
-	shiftSemesterSeasons: {
+	uiShiftSeasons: {
 		isValid: isBoolean,
 	},
 	previous_notification: { // eslint-disable-line camelcase

--- a/lib/services/validation/user-settings.js
+++ b/lib/services/validation/user-settings.js
@@ -28,6 +28,9 @@ const settings = {
 	redirectFromHome: {
 		isValid: isBoolean,
 	},
+	shiftSemesterSeasons: {
+		isValid: isBoolean,
+	},
 	previous_notification: { // eslint-disable-line camelcase
 		isValid: value => new Date(value).toString() !== 'Invalid Date',
 	},


### PR DESCRIPTION
Add new user setting to allow semester display names to be shifted to match southern hemisphere seasons.

Reviewers: 1
Merge: Squash