### PR TITLE
use package.json#engines.node for actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: gradebook/actions/actions/setup@master
+      with:
+        node-version: package_json
     - name: Install Dependencies and setup
       run: |
         yarn install --frozen-lockfile --prefer-offline
@@ -43,6 +45,8 @@ jobs:
       NODE_ENV: testing
     steps:
     - uses: gradebook/actions/actions/setup@master
+      with:
+        node-version: package_json
     - name: Configure Dependencies
       run: |
         yarn install --frozen-lockfile --prefer-offline
@@ -75,6 +79,8 @@ jobs:
     timeout-minutes: 5
     steps:
     - uses: gradebook/actions/actions/setup@master
+      with:
+        node-version: package_json
     - name: Install dependencies and setup
       run: yarn install --frozen-lockfile --prefer-offline
     - name: Lint and Typecheck

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: gradebook/actions/actions/setup@master
       with:
         git-ref: ${{ env.SERVER_REF }}
-        node-version: 18.20.x
+        node-version: package_json
     - name: Install Dependencies and Setup
       run: |
         yarn install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
Maintain a single source of truth instead of having it in multiple places.

No reviewers, CI only