### PR TITLE
Allow for decimal gpa overall credits

### DIFF
--- a/lib/services/validation/schemas/user-gpa-settings.json
+++ b/lib/services/validation/schemas/user-gpa-settings.json
@@ -16,7 +16,7 @@
       "maximum": 5
     },
     "overallCredits": {
-      "type": "integer",
+      "type": "number",
       "minimum": 0,
       "exclusiveMaximum": 1000
     },

--- a/test/unit/schemas/user-gpa-settings.spec.js
+++ b/test/unit/schemas/user-gpa-settings.spec.js
@@ -28,13 +28,13 @@ describe('Unit > Schemas > UserGpaSettings', function () {
 		expectInvalid(object, errorProp, 'must be >= 0');
 
 		object.overallCredits = 15.3;
-		expectInvalid(object, errorProp, 'integer');
+		expectValid(object);
 
 		object.overallCredits = null;
-		expectInvalid(object, errorProp, 'integer');
+		expectInvalid(object, errorProp, 'number');
 
 		object.overallCredits = 'Introduction to Gradebook';
-		expectInvalid(object, errorProp, 'integer');
+		expectInvalid(object, errorProp, 'number');
 
 		object.overallCredits = 45;
 		expectValid(object);


### PR DESCRIPTION
In allowing for decimal credit hours on courses, we forgot to allow partial credit hours for overall GPA.